### PR TITLE
Fixes for the CUDA build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,16 @@
 
 cmake_minimum_required(VERSION 3.4)
 
-project(care)
+project(care LANGUAGES CXX)
+
+################################
+# Build options
+################################
+set(ENABLE_CUDA OFF CACHE BOOL "Build CUDA support")
+set(ENABLE_OPENMP OFF CACHE BOOL "Build OpenMP support")
+set(ENABLE_TESTS ON CACHE BOOL "Build tests")
+set(ENABLE_BENCHMARKS ON CACHE BOOL "Build benchmarks")
+set(ENABLE_DOCUMENTATION ON CACHE BOOL "Build documentation")
 
 ################################
 # BLT
@@ -26,10 +35,26 @@ endif()
 
 include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 
+################################
+# Set up compiler flags
+################################
+if (ENABLE_CUDA)
+   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda -arch=sm_35")
+endif()
+
+################################
+# Set up dependencies
+################################
 include(cmake/SetupLibraries.cmake)
 
+################################
+# Build CARE library
+################################
 add_subdirectory(src)
 
+################################
+# Build CARE extras
+################################
 if (ENABLE_TESTS)
    add_subdirectory(test)
 endif()

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Note: CHAI must be built with `-DENABLE_PICK=ON -DENABLE_PINNED=ON`.
 
 For quick reference, the paths to CHAI, RAJA, and Umpire are the same as CMAKE\_INSTALL\_PREFIX when building those dependencies. That location defaults to /usr/local, but can be specified by passing `-DCMAKE_INSTALL_PREFIX=/desired/path` and running `make install`.
 
+To build with CUDA support, use `-DENABLE_CUDA -DCUDA_TOOLKIT_ROOT_DIR=/path/to/cuda/toolkit`. CHAI, RAJA, and Umpire must also be built with those options.
+
+To build with OpenMP support, use `-DENABLE_OPENMP`. RAJA must also be built with that option.
+
 License
 =======
 CARE is release under the BSD-3-Clause License. See the LICENSE and NOTICE files for more details.

--- a/benchmarks/BenchmarkNumeric.cpp
+++ b/benchmarks/BenchmarkNumeric.cpp
@@ -12,6 +12,7 @@
 #include <benchmark/benchmark.h>
 
 // CARE headers
+#include "care/care.h"
 #include "care/numeric.h"
 
 static void benchmark_std_iota(benchmark::State& state) {

--- a/src/care/CMakeLists.txt
+++ b/src/care/CMakeLists.txt
@@ -66,14 +66,21 @@ else()
         )
 endif()
 
-if (LLNL_GLOBALID_DIR)
+if (LLNL_GLOBALID_FOUND)
    list (APPEND care_depends llnl_globalid)
 endif()
 
 if (ENABLE_CUDA)
    # separable compilation, delay all device linking to executable linking time
    # set (CUDA_SEPARABLE_COMPILATION ON BOOL "" )
-   list(APPEND care_depends basil)
+   if (BASIL_FOUND)
+      list(APPEND care_depends basil)
+   endif()
+
+   if (NVTOOLSEXT_FOUND)
+      list(APPEND care_depends nvtoolsext)
+   endif()
+
    list(APPEND care_depends cuda)
 endif()
 

--- a/src/care/RAJAPlugin.cpp
+++ b/src/care/RAJAPlugin.cpp
@@ -15,7 +15,7 @@
 #include "chai/ArrayManager.hpp"
 
 /* CUDA profiling macros */
-#ifdef __CUDACC__
+#if defined(__CUDACC__) && CARE_HAVE_NVTOOLSEXT
 #include "nvToolsExt.h"
 #endif
 
@@ -78,6 +78,7 @@ namespace care {
          }
       }
 
+#if CARE_HAVE_NVTOOLSEXT
       // Profile the host loops
       if (s_profile_host_loops) {
          if (space == chai::CPU) {
@@ -97,6 +98,7 @@ namespace care {
             nvtxRangePushEx(&eventAttrib);
          }
       }
+#endif // CARE_HAVE_NVTOOLSEXT
 #endif // defined(__CUDACC__)
    }
 
@@ -183,12 +185,14 @@ namespace care {
 
    void RAJAPlugin::post_forall_hook(chai::ExecutionSpace space, const char* fileName, int lineNumber) {
 #if defined(__CUDACC__)
+#if CARE_HAVE_NVTOOLSEXT
       if (s_profile_host_loops) {
          if (space == chai::CPU) {
             // TODO: Add error checking
             nvtxRangePop();
          }
       }
+#endif // CARE_HAVE_NVTOOLSEXT
 
       if (s_synchronize_after) {
          if (space == chai::GPU) {

--- a/src/care/forall.h
+++ b/src/care/forall.h
@@ -17,8 +17,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 // CARE headers
-#include "care/CHAIDataGetter.h"
-#include "care/CUDAWatchpoint.h"
 #include "care/policies.h"
 #include "care/RAJAPlugin.h"
 #include "care/util.h"
@@ -67,7 +65,7 @@ namespace care {
       const int length = end - start;
 
       if (length != 0) {
-         care::RAJAPlugin::pre_forall_hook(ExecutionPolicyToSpace<ExecutionPolicy>::value, fileName, lineNumber);
+         RAJAPlugin::pre_forall_hook(ExecutionPolicyToSpace<ExecutionPolicy>::value, fileName, lineNumber);
 
 #if CARE_ENABLE_GPU_SIMULATION_MODE
          RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(start, end), body);
@@ -75,7 +73,7 @@ namespace care {
          RAJA::forall<ExecutionPolicy>(RAJA::RangeSegment(start, end), body);
 #endif
 
-         care::RAJAPlugin::post_forall_hook(ExecutionPolicyToSpace<ExecutionPolicy>::value, fileName, lineNumber);
+         RAJAPlugin::post_forall_hook(ExecutionPolicyToSpace<ExecutionPolicy>::value, fileName, lineNumber);
       }
    }
 

--- a/src/care/util.h
+++ b/src/care/util.h
@@ -77,21 +77,21 @@ namespace care {
 
    template <typename T,
              typename std::enable_if<detail::is_detected<stream_insertion_t, T>::value, int>::type = 0>
-   void print(std::ostream& os, const T& obj)
+   inline void print(std::ostream& os, const T& obj)
    {
       os << obj;
    }
 
    template <typename T,
              typename std::enable_if<!detail::is_detected<stream_insertion_t, T>::value, int>::type = 0>
-   void print(std::ostream& os, const T& obj)
+   inline void print(std::ostream& os, const T& obj)
    {
       os << "operator<< is not supported for type " << typeid(obj).name();
    }
 
    template <typename T,
              typename std::enable_if<detail::is_detected<stream_insertion_t, T>::value, int>::type = 0>
-   void print(std::ostream& os, const T* array, size_t size)
+   inline void print(std::ostream& os, const T* array, size_t size)
    {
       // Write out size
       os << "[CARE] Size: " << size << std::endl;
@@ -124,7 +124,7 @@ namespace care {
 
    template <typename T,
              typename std::enable_if<!detail::is_detected<stream_insertion_t, T>::value, int>::type = 0>
-   void print(std::ostream& os, const T* /* array */, size_t size)
+   inline void print(std::ostream& os, const T* /* array */, size_t size)
    {
       // Write out size
       os << "[CARE] Size: " << size << std::endl;

--- a/test/TestNestedMA.cpp
+++ b/test/TestNestedMA.cpp
@@ -5,12 +5,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////////////
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__)
 #define GPU_ACTIVE
-// This asserts a crash on the GPU, but does not mark gtest as passing.
-#define GPU_FAIL(code) ASSERT_DEATH(code, "")
-#else
-#define GPU_FAIL(code) code
 #endif
 
 // other library headers
@@ -18,6 +14,13 @@
 
 // care headers
 #include "care/care.h"
+
+#if defined(__CUDACC__) && GTEST_HAS_DEATH_TEST
+// This asserts a crash on the GPU, but does not mark gtest as passing.
+#define GPU_FAIL(code) ASSERT_DEATH(code, "")
+#else
+#define GPU_FAIL(code) code
+#endif
 
 // This makes it so we can use device lambdas from within a CUDA_TEST
 #define CUDA_TEST(X, Y) static void cuda_test_ ## X_ ## Y(); \


### PR DESCRIPTION
This pull request fixes several issues for the CUDA build. It makes basil and nvtoolsext optional dependencies. It also makes gtest death tests optional (they are not necessarily supported on all platforms).