### PR TITLE
bugfix/taller1/fixbindarysearchbug 

### DIFF
--- a/src/care/array_utils.h
+++ b/src/care/array_utils.h
@@ -265,7 +265,7 @@ inline void IntersectArrays(RAJAExec,
    *numMatches = 0 ;
    int smaller = (size1 < size2) ? size1 : size2 ;
 
-   if (smaller == 0) {
+   if (smaller == 0 || start1 >= size1 || start2 >= size2) {
       matches1 = nullptr ;
       matches2 = nullptr ;
       return ;
@@ -393,7 +393,7 @@ inline void IntersectArrays(RAJA::seq_exec,
    *numMatches = 0 ;
    int smaller = (size1 < size2) ? size1 : size2 ;
 
-   if (smaller == 0) {
+   if (smaller <= 0 || start1 >= size1 || start2 >= size2) {
       matches1 = nullptr ;
       matches2 = nullptr ;
       return ;
@@ -582,12 +582,12 @@ inline int BinarySearch(const T *map, const int start,
       if (khi < start + mapSize) {
          // Note: fix for last test in TEST(array_utils, binarysearch). This algorithm has failed to pick up the upper
          // bound above 1 in the array {0, 1, 1, 1, 1, 1, 6}. Having 1 repeated confused the algorithm.
-         while (map[khi] == num && khi < start + mapSize) {
+         while ((khi < start + mapSize) && (map[khi] == num)) {
             ++khi;
          }
 
          // the upper option bounds num
-         if (map[khi] > num) {
+         if ((khi < start + mapSize) && (map[khi] > num)) {
             return khi;
          }
          // neither the upper or lower option bound num

--- a/src/care/array_utils.h
+++ b/src/care/array_utils.h
@@ -265,7 +265,7 @@ inline void IntersectArrays(RAJAExec,
    *numMatches = 0 ;
    int smaller = (size1 < size2) ? size1 : size2 ;
 
-   if (smaller == 0 || start1 >= size1 || start2 >= size2) {
+   if (smaller <= 0 || start1 >= size1 || start2 >= size2) {
       matches1 = nullptr ;
       matches2 = nullptr ;
       return ;

--- a/test/TestArrayUtils.cpp
+++ b/test/TestArrayUtils.cpp
@@ -88,6 +88,7 @@ TEST(array_utils, binarysearch) {
    int* nil = nullptr;
    int  a[7] = {-9, 0, 3, 7, 77, 500, 999}; // sorted no duplicates
    int  b[7] = {0, 1, 1, 1, 1, 1, 6};       // sorted with duplicates
+   int  c[7] = {1, 1, 1, 1, 1, 1, 1};       // uniform array edge case.
    int result = 0;
   
    // nil test
@@ -121,6 +122,10 @@ TEST(array_utils, binarysearch) {
    // turn on upper bound, should ge the value after all of the ones.
    result = care_utils::BinarySearch<int>(b, 0, 7, 1, true);
    EXPECT_EQ(result, 6);
+
+   // check upper bound on uniform arrary as an edge case
+   result = care_utils::BinarySearch<int>(c, 0, 7, 1, true);
+   EXPECT_EQ(result, -1);
 }
 
 TEST(array_utils, intersectarrays) {


### PR DESCRIPTION
some fixes to binary search and intersect arrays. 

* Binary search with upper bound was failing for {1,1,1,1,1,1}
* IntersectArrays can take starting indicies. Should exit immediately if start >= size, to avoid an invalid read memory error later on.