### PR TITLE
feature/dtaller/disableimplicit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,8 @@ option(ENABLE_BENCHMARKS "Build benchmarks" ON)
 option(ENABLE_DOCUMENTATION "Build documentation" ON)
 option(ENABLE_EXAMPLES "Build examples" ON)
 
-# The same value should be used when building CHAI
+# Option to diable implicit conversion between host_device_ptr and raw arrays. 
+# The same value used here should be used when building CHAI
 option(ENABLE_IMPLICIT_CONVERSIONS "Enable implicit conversions to-from raw pointers" ON)
 
 # Dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ option(ENABLE_BENCHMARKS "Build benchmarks" ON)
 option(ENABLE_DOCUMENTATION "Build documentation" ON)
 option(ENABLE_EXAMPLES "Build examples" ON)
 
+# The same value should be used when building CHAI
+option(ENABLE_IMPLICIT_CONVERSIONS "Enable implicit conversions to-from raw pointers" ON)
+
 # Dependencies
 set(BLT_SOURCE_DIR "" CACHE PATH "Path to external BLT")
 set(camp_DIR "" CACHE PATH "Path to external campConfig.cmake or camp-config.cmake")

--- a/benchmarks/BenchmarkNumeric.cpp
+++ b/benchmarks/BenchmarkNumeric.cpp
@@ -6,7 +6,8 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 // Std library headers
-#include <numeric>
+#include <numeric> // for std::iota (which will be compared to care::iota)
+#include <climits> // for INT_MAX
 
 // Other library headers
 #include <benchmark/benchmark.h>
@@ -20,7 +21,7 @@ static void benchmark_std_iota(benchmark::State& state) {
    const int size = state.range(0);
 
    care::host_device_ptr<int> data(size, "data");
-   int* host_data = data;
+   int* host_data = data.data();
 
    while (state.KeepRunning()) {
       std::iota(host_data, host_data + size, 0);

--- a/src/care/CMakeLists.txt
+++ b/src/care/CMakeLists.txt
@@ -11,6 +11,8 @@ if (WIN32)
   endif ()
 endif ()
 
+set(CARE_ENABLE_IMPLICIT_CONVERSIONS ${ENABLE_IMPLICIT_CONVERSIONS})
+
 configure_file(
     ${PROJECT_SOURCE_DIR}/src/care/config.h.in
     ${PROJECT_BINARY_DIR}/include/care/config.h)

--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -72,6 +72,7 @@ namespace care {
       ///
       CARE_HOST_DEVICE host_device_ptr<T>(std::nullptr_t from) noexcept : MA (from) {}
 
+#if defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
       ///
       /// @author Peter Robinson
       ///
@@ -85,6 +86,7 @@ namespace care {
          chai::CHAIDISAMBIGUATE name=chai::CHAIDISAMBIGUATE(), //!< Used to disambiguate this constructor
          bool foo=Q) //!< Used to disambiguate this constructor
       : MA(from, name, foo) {}
+#endif
 
       ///
       /// @author Peter Robinson

--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -398,6 +398,15 @@ namespace care {
       }
    }; // class host_device_ptr
 
+
+   // When ENABLE_IMPLICIT_CONVERSIONS is off, this line is needed for the line 'using stream_insertion_t = decltype(std::cout << std::declval<T>());' in
+   // util.h to compile
+   template<typename T>
+   std::ostream& operator<<(std::ostream& outs, const host_device_ptr<T>& ptr)
+   {
+     return outs << ptr.data();
+   }
+
    /* This is intentionally declared after the use above, which will cause a compiler error if the non const [] is used on host_device pointers */
    template< typename T>
    void using_host_device_ptr_outside_of_raja_loop_not_allowed(T foo); 

--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -399,12 +399,13 @@ namespace care {
    }; // class host_device_ptr
 
 
+   // Prints host_device data to the given ostream. 
    // When ENABLE_IMPLICIT_CONVERSIONS is off, this line is needed for the line 'using stream_insertion_t = decltype(std::cout << std::declval<T>());' in
-   // util.h to compile
+   // util.h to compile.
    template<typename T>
-   std::ostream& operator<<(std::ostream& outs, const host_device_ptr<T>& ptr)
-   {
-     return outs << ptr.data();
+   std::ostream& operator<<(std::ostream& os, const host_device_ptr<T>& ptr) {
+     print(os, ptr.data(), ptr.size());
+     return os;
    }
 
    /* This is intentionally declared after the use above, which will cause a compiler error if the non const [] is used on host_device pointers */

--- a/src/care/host_ptr.h
+++ b/src/care/host_ptr.h
@@ -58,7 +58,7 @@ namespace care {
          ///
          /// Copy constructor
          ///
-         host_ptr(host_ptr const & ptr) noexcept : m_ptr(ptr) {}
+         host_ptr(host_ptr const & ptr) noexcept : m_ptr(ptr.data()) {}
 
          ///
          /// @author Peter Robinson
@@ -67,14 +67,14 @@ namespace care {
          ///
          template <bool B = std::is_const<T>::value,
                    typename std::enable_if<B, int>::type = 1>
-         host_ptr<T>(host_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr) {}
+         host_ptr<T>(host_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr.data()) {}
 
          ///
          /// @author Peter Robinson
          ///
          /// Construct from chai::ManagedArray
          ///
-         host_ptr(chai::ManagedArray<T> const &ptr) : m_ptr((T*) ptr) {}
+         host_ptr(chai::ManagedArray<T> const &ptr) : m_ptr((T*) ptr.data()) {}
 
          ///
          /// @author Peter Robinson
@@ -83,7 +83,7 @@ namespace care {
          ///
          template <bool B = std::is_const<T>::value,
                    typename std::enable_if<B, int>::type = 1>
-         host_ptr<T>(chai::ManagedArray<T_non_const> const &ptr) : m_ptr((T_non_const*) ptr) {}
+         host_ptr<T>(chai::ManagedArray<T_non_const> const &ptr) : m_ptr((T_non_const*) ptr.data()) {}
 
          ///
          /// @author Peter Robinson
@@ -92,12 +92,16 @@ namespace care {
          ///
          inline T & operator[](int index) const { return m_ptr[index]; }
 
+// We will allow this implicit conversion since it is safe for host-only pointers. We could re-consider
+// this in the future, however, but it may require many code changes for users.
+//#if defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
          ///
          /// @author Peter Robinson
          ///
          /// Convert to a raw pointer
          ///
          operator T*() const { return m_ptr; }
+//#endif
 
          ///
          /// @author Peter Robinson
@@ -120,6 +124,13 @@ namespace care {
          ///
          template<typename Idx>
          host_ptr<T> & operator +=(Idx i) { m_ptr += i; return *this; }
+
+         ///
+         /// @author Danny Taller
+         ///
+         /// Get the underlying data array. In the future, this may replace operator T*()
+         ///
+         T* data() const { return m_ptr; }
 
       private:
          T * m_ptr; //!< Raw host pointer


### PR DESCRIPTION
Adds option to disable implicit conversions between host_device_ptr and raw arrays. These often cause errors when data is copied to/from the device.

EDIT: After discussions with Alan, we decided to leave implicit conversions on for host_ptrs for the time being. That could be fixed in a future update. Allowing implicit conversions for host_ptr is less dangerous because we don't copy data from host/device.

This pull request is related to the pull request https://github.com/LLNL/CHAI/pull/125/files/6bd5fe7e506432defe70582d4bf53a87122f1199..7820b09e38cb28f58bd5fff839275004770f3ece .

