### PR TITLE
yet more fixes for disbaling implicit casts

### DIFF
--- a/src/care/array_utils.h
+++ b/src/care/array_utils.h
@@ -183,7 +183,7 @@ CARE_HOST_DEVICE bool checkSorted(const T* array, const int len,
 
 #if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 template <typename T>
-CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<T>& array, const int len,
+CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<const T>& array, const int len,
                                   const char* name, const char* argname,
                                   const bool allowDuplicates = false);
 #endif
@@ -242,11 +242,11 @@ CARE_HOST_DEVICE bool checkSorted(const T* array, const int len,
 
 #if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 template <typename T>
-CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<T>& array, const int len,
+CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<const T>& array, const int len,
                                   const char* name, const char* argname,
                                   const bool allowDuplicates)
 {
-   return checkSorted<T>(array.data(), len, name, argname, allowDuplicates);
+   return checkSorted<const T>(array.data(), len, name, argname, allowDuplicates);
 }
 #endif
 
@@ -258,9 +258,9 @@ CARE_HOST_DEVICE int BinarySearch(const mapType *map, const int start,
 #if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 // this is needed when implicit cast to mapType* is disabled
 template<typename mapType>
-CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<mapType>& map, const int start,
-                             const int mapSize, const mapType num,
-                             bool returnUpperBound = false) ;
+CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<const mapType>& map, const int start,
+                                  const int mapSize, const mapType num,
+                                  bool returnUpperBound = false) ;
 #endif
 
 template <typename ArrayType, typename Exec>
@@ -313,8 +313,8 @@ inline void IntersectArrays(RAJAExec,
       const char* funcname = "IntersectArrays" ;
 
       // allowDuplicates is false for these checks by default.
-      checkSorted<const ArrayType>(arr1, size1, funcname, "arr1") ;
-      checkSorted<const ArrayType>(arr2, size2, funcname, "arr2") ;
+      checkSorted<ArrayType>(arr1, size1, funcname, "arr1") ;
+      checkSorted<ArrayType>(arr2, size2, funcname, "arr2") ;
    }
 
    care::host_device_ptr<int> smallerMatches, largerMatches;
@@ -345,7 +345,7 @@ inline void IntersectArrays(RAJAExec,
    care::host_device_ptr<int> matched(smaller + 1, "IntersectArrays matched");
 
    LOOP_STREAM(i, 0, smaller + 1) {
-      searches[i] = i != smaller ? BinarySearch<const ArrayType>(largerArray, largeStart, larger, smallerArray[i + smallStart]) : -1;
+      searches[i] = i != smaller ? BinarySearch<ArrayType>(largerArray, largeStart, larger, smallerArray[i + smallStart]) : -1;
       matched[i] = i != smaller && searches[i] > -1;
    } LOOP_STREAM_END
 
@@ -635,16 +635,16 @@ CARE_HOST_DEVICE inline int BinarySearch(const T *map, const int start,
 
 #if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 template<typename mapType>
-CARE_HOST_DEVICE inline int BinarySearch(const care::host_device_ptr<mapType>& map, const int start,
+CARE_HOST_DEVICE inline int BinarySearch(const care::host_device_ptr<const mapType>& map, const int start,
                                          const int mapSize, const mapType num,
                                          bool returnUpperBound)
 {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) 
-   return BinarySearch<mapType>(map.data(), start, mapSize, num, returnUpperBound);
+   return BinarySearch<const mapType>(map.data(), start, mapSize, num, returnUpperBound);
 #else
    int result = -1;
    LOOP_SEQUENTIAL_REF(i, 0, 1, result) {
-      result = BinarySearch<mapType>(map.data(), start, mapSize, num, returnUpperBound);
+      result = BinarySearch<const mapType>(map.data(), start, mapSize, num, returnUpperBound);
    } LOOP_SEQUENTIAL_REF_END
 
    return result;

--- a/src/care/array_utils.h
+++ b/src/care/array_utils.h
@@ -263,6 +263,13 @@ CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<mapType>& map, con
                              bool returnUpperBound = false) ;
 #endif
 
+template <typename ArrayType, typename Exec>
+inline void IntersectArrays(Exec,
+                            care::host_device_ptr<const ArrayType> arr1, int size1, int start1,
+                            care::host_device_ptr<const ArrayType> arr2, int size2, int start2,
+                            care::host_device_ptr<int> &matches1, care::host_device_ptr<int> &matches2,
+                            int *numMatches);
+
 /************************************************************************
  * Function  : IntersectArrays<A,RAJAExec>
  * Author(s) : Peter Robinson, based on IntersectGlobalIDArrays by Al Nichols

--- a/src/care/array_utils.h
+++ b/src/care/array_utils.h
@@ -246,6 +246,14 @@ CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<const T>& array, c
    return checkSorted<const T>(array.data(), len, name, argname, allowDuplicates);
 }
 
+template <typename T>
+CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<T>& array, const int len,
+                                  const char* name, const char* argname,
+                                  const bool allowDuplicates)
+{
+   return checkSorted<const T>(array.data(), len, name, argname, allowDuplicates);
+}
+
 template<typename mapType>
 CARE_HOST_DEVICE int BinarySearch(const mapType *map, const int start,
                              const int mapSize, const mapType num,
@@ -253,6 +261,11 @@ CARE_HOST_DEVICE int BinarySearch(const mapType *map, const int start,
 
 template<typename mapType>
 CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<const mapType>& map, const int start,
+                                  const int mapSize, const mapType num,
+                                  bool returnUpperBound = false) ;
+
+template<typename mapType>
+CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<mapType>& map, const int start,
                                   const int mapSize, const mapType num,
                                   bool returnUpperBound = false) ;
 
@@ -627,6 +640,14 @@ CARE_HOST_DEVICE inline int BinarySearch(const T *map, const int start,
 }
 
 template<typename mapType>
+CARE_HOST_DEVICE inline int BinarySearch(const care::host_device_ptr<mapType>& map, const int start,
+                                         const int mapSize, const mapType num,
+                                         bool returnUpperBound)
+{
+   return BinarySearch<const mapType>(map.data(), start, mapSize, num, returnUpperBound);
+}
+
+template<typename mapType>
 CARE_HOST_DEVICE inline int BinarySearch(const care::host_device_ptr<const mapType>& map, const int start,
                                          const int mapSize, const mapType num,
                                          bool returnUpperBound)
@@ -939,7 +960,7 @@ inline void CompressArray(RAJAExec exec, care::host_device_ptr<T> & arr, const i
    care::host_device_ptr<T> tmp(arrLen-removedLen, "CompressArray_tmp");
    int numKept = 0;
    SCAN_LOOP(i, 0, arrLen, pos, numKept,
-             -1 == BinarySearch<int const>(removed, 0, removedLen, i)) {
+             -1 == BinarySearch<int>(removed, 0, removedLen, i)) {
       tmp[pos] = arr[i];
    } SCAN_LOOP_END(arrLen, pos, numKept)
 

--- a/src/care/array_utils.h
+++ b/src/care/array_utils.h
@@ -639,16 +639,7 @@ CARE_HOST_DEVICE inline int BinarySearch(const care::host_device_ptr<const mapTy
                                          const int mapSize, const mapType num,
                                          bool returnUpperBound)
 {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) 
    return BinarySearch<const mapType>(map.data(), start, mapSize, num, returnUpperBound);
-#else
-   int result = -1;
-   LOOP_SEQUENTIAL_REF(i, 0, 1, result) {
-      result = BinarySearch<const mapType>(map.data(), start, mapSize, num, returnUpperBound);
-   } LOOP_SEQUENTIAL_REF_END
-
-   return result;
-#endif
 }
 #endif
 

--- a/src/care/array_utils.h
+++ b/src/care/array_utils.h
@@ -181,6 +181,7 @@ CARE_HOST_DEVICE bool checkSorted(const T* array, const int len,
                                   const bool allowDuplicates = false);
 
 
+// TODO: revisit macro guard when CHAI is updated
 #if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 template <typename T>
 CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<const T>& array, const int len,
@@ -240,6 +241,7 @@ CARE_HOST_DEVICE bool checkSorted(const T* array, const int len,
    return true;
 }
 
+// TODO: revisit macro guard when CHAI is updated
 #if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 template <typename T>
 CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<const T>& array, const int len,
@@ -255,6 +257,7 @@ CARE_HOST_DEVICE int BinarySearch(const mapType *map, const int start,
                              const int mapSize, const mapType num,
                              bool returnUpperBound = false) ;
 
+// TODO: revisit macro guard when CHAI is updated
 #if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 // this is needed when implicit cast to mapType* is disabled
 template<typename mapType>
@@ -633,6 +636,7 @@ CARE_HOST_DEVICE inline int BinarySearch(const T *map, const int start,
    }
 }
 
+// TODO: revisit macro guard when CHAI is updated
 #if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 template<typename mapType>
 CARE_HOST_DEVICE inline int BinarySearch(const care::host_device_ptr<const mapType>& map, const int start,

--- a/src/care/array_utils.h
+++ b/src/care/array_utils.h
@@ -181,13 +181,10 @@ CARE_HOST_DEVICE bool checkSorted(const T* array, const int len,
                                   const bool allowDuplicates = false);
 
 
-// TODO: revisit macro guard when CHAI is updated
-#if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 template <typename T>
 CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<const T>& array, const int len,
                                   const char* name, const char* argname,
                                   const bool allowDuplicates = false);
-#endif
 
 ///////////////////////////////////////////////////////////////////////////
 /// @author Ben Liu, Peter Robinson, Alan Dayton
@@ -241,8 +238,6 @@ CARE_HOST_DEVICE bool checkSorted(const T* array, const int len,
    return true;
 }
 
-// TODO: revisit macro guard when CHAI is updated
-#if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 template <typename T>
 CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<const T>& array, const int len,
                                   const char* name, const char* argname,
@@ -250,21 +245,16 @@ CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<const T>& array, c
 {
    return checkSorted<const T>(array.data(), len, name, argname, allowDuplicates);
 }
-#endif
 
 template<typename mapType>
 CARE_HOST_DEVICE int BinarySearch(const mapType *map, const int start,
                              const int mapSize, const mapType num,
                              bool returnUpperBound = false) ;
 
-// TODO: revisit macro guard when CHAI is updated
-#if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
-// this is needed when implicit cast to mapType* is disabled
 template<typename mapType>
 CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<const mapType>& map, const int start,
                                   const int mapSize, const mapType num,
                                   bool returnUpperBound = false) ;
-#endif
 
 template <typename ArrayType, typename Exec>
 inline void IntersectArrays(Exec,
@@ -636,8 +626,6 @@ CARE_HOST_DEVICE inline int BinarySearch(const T *map, const int start,
    }
 }
 
-// TODO: revisit macro guard when CHAI is updated
-#if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 template<typename mapType>
 CARE_HOST_DEVICE inline int BinarySearch(const care::host_device_ptr<const mapType>& map, const int start,
                                          const int mapSize, const mapType num,
@@ -645,7 +633,6 @@ CARE_HOST_DEVICE inline int BinarySearch(const care::host_device_ptr<const mapTy
 {
    return BinarySearch<const mapType>(map.data(), start, mapSize, num, returnUpperBound);
 }
-#endif
 
 
 #ifdef RAJA_PARALLEL_ACTIVE

--- a/src/care/device_ptr.h
+++ b/src/care/device_ptr.h
@@ -78,7 +78,7 @@ namespace care {
          ///
          /// Construct from chai::ManagedArray
          ///
-         CARE_HOST_DEVICE device_ptr(chai::ManagedArray<T> const &ptr) : m_ptr(ptr) {}
+         CARE_HOST_DEVICE device_ptr(chai::ManagedArray<T> const &ptr) : m_ptr(ptr.data()) {}
 
          ///
          /// @author Peter Robinson
@@ -87,7 +87,7 @@ namespace care {
          ///
          template <bool B = std::is_const<T>::value,
                    typename std::enable_if<B, int>::type = 1>
-         CARE_HOST_DEVICE device_ptr(chai::ManagedArray<T_non_const> const &ptr) : m_ptr(ptr) {}
+         CARE_HOST_DEVICE device_ptr(chai::ManagedArray<T_non_const> const &ptr) : m_ptr(ptr.data()) {}
          
          ///
          /// @author Peter Robinson

--- a/src/care/local_ptr.h
+++ b/src/care/local_ptr.h
@@ -89,7 +89,7 @@ namespace care {
          ///
          /// Construct from chai::ManagedArray
          ///
-         CARE_HOST_DEVICE local_ptr<T>(chai::ManagedArray<T> const &ptr) : m_ptr(ptr) {}
+         CARE_HOST_DEVICE local_ptr<T>(chai::ManagedArray<T> const &ptr) : m_ptr(ptr.data()) {}
 
          ///
          /// @author Peter Robinson
@@ -98,7 +98,7 @@ namespace care {
          ///
          template <bool B = std::is_const<T>::value,
                    typename std::enable_if<B, int>::type = 1>
-         CARE_HOST_DEVICE local_ptr<T>(chai::ManagedArray<T_non_const> const &ptr) : m_ptr(ptr) {}
+         CARE_HOST_DEVICE local_ptr<T>(chai::ManagedArray<T_non_const> const &ptr) : m_ptr(ptr.data()) {}
 
          ///
          /// @author Peter Robinson

--- a/test/TestArrayUtils.cpp
+++ b/test/TestArrayUtils.cpp
@@ -91,6 +91,8 @@ TEST(array_utils, binarysearch) {
    int  a[7] = {-9, 0, 3, 7, 77, 500, 999}; // sorted no duplicates
    int  b[7] = {0, 1, 1, 1, 1, 1, 6};       // sorted with duplicates
    int  c[7] = {1, 1, 1, 1, 1, 1, 1};       // uniform array edge case.
+   care::host_ptr<int> aptr(a);
+
    int result = 0;
   
    // nil test
@@ -99,6 +101,9 @@ TEST(array_utils, binarysearch) {
 
    // search for 77
    result = care_utils::BinarySearch<int>(a, 0, 7, 77, false);
+   EXPECT_EQ(result, 4);
+
+   result = care_utils::BinarySearch<int>(aptr, 0, 7, 77, false);
    EXPECT_EQ(result, 4);
 
    // start after the number
@@ -1159,13 +1164,11 @@ GPU_TEST(array_utils, dup_and_copy) {
   ASSERT_TRUE((bool) passed3);
 }
 
-
 GPU_TEST(array_utils, intersectarrays) {
    int tempa[3] = {1, 2, 5};
    int tempb[5] = {2, 3, 4, 5, 6};
    int tempc[7] = {-1, 0, 2, 3, 6, 120, 360};
    int tempd[9] = {1001, 1002, 2003, 3004, 4005, 5006, 6007, 7008, 8009};
-   int* nil = nullptr;
    care::host_device_ptr<int> a(tempa, 3, "a");
    care::host_device_ptr<int> b(tempb, 5, "b");
    care::host_device_ptr<int> c(tempc, 7, "c");
@@ -1175,7 +1178,7 @@ GPU_TEST(array_utils, intersectarrays) {
    int numMatches[1] = {77};
 
    // nil test
-   care_utils::IntersectArrays<int>(RAJAExec(), c, 7, 0, nil, 0, 0, matches1, matches2, numMatches);
+   care_utils::IntersectArrays<int>(RAJAExec(), c, 7, 0, nullptr, 0, 0, matches1, matches2, numMatches);
    EXPECT_EQ(numMatches[0], 0);
 
    // intersect c and b
@@ -1212,6 +1215,16 @@ GPU_TEST(array_utils, intersectarrays) {
    // no matches
    care_utils::IntersectArrays<int>(RAJAExec(), a, 3, 0, d, 9, 0, matches1, matches2, numMatches);
    EXPECT_EQ(numMatches[0], 0);
+}
+
+GPU_TEST(array_utils, binarsearchhostdev) {
+   int  a[7] = {-9, 0, 3, 7, 77, 500, 999}; // sorted no duplicates
+   care::host_device_ptr<int> aptr(a, 7, "asorted");
+
+   int result = 0;
+   
+   result = care_utils::BinarySearch<int>(aptr, 0, 7, 77, false);
+   EXPECT_EQ(result, 4);
 }
 
 #endif // __GPUCC__


### PR DESCRIPTION
I made a version of binary search and check sorted that can take in a host device pointer (without an implicit cast). Some other minor fixes 