### PR TITLE
Disable managed_ptr stuff in the HIP build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(ENABLE_PINNED "Enable pinned memory space (used for scans)" ON)
 # Option to diable implicit conversion between host_device_ptr and raw arrays. 
 # The same value used here should be used when building CHAI
 option(CARE_ENABLE_IMPLICIT_CONVERSIONS "Enable implicit conversions to-from raw pointers" ON)
+option(CARE_ENABLE_MANAGED_PTR "Enable managed_ptr aliases, tests, and reproducer" ON)
 
 # Extra components
 option(CARE_ENABLE_TESTS "Build CARE tests" ON)

--- a/configs/lc/hip/rocm-3.6-43-20200704_clang11.0.0.cmake
+++ b/configs/lc/hip/rocm-3.6-43-20200704_clang11.0.0.cmake
@@ -11,3 +11,5 @@ set(HCC_AMDGPU_TARGET "gfx900" CACHE STRING "Set the AMD actual architecture")
 set(CMAKE_CXX_COMPILER "/opt/rocm/llvm/bin/clang++" CACHE FILEPATH "Path to clang++")
 set(CMAKE_C_COMPILER "/opt/rocm/llvm/bin/clang" CACHE FILEPATH "Path to clang++")
 
+# Virtual functions are not supported in HIP device code
+set(CARE_ENABLE_MANAGED_PTR OFF CACHE BOOL "Enable aliases, tests, and reproducer for managed_ptr")

--- a/reproducers/CMakeLists.txt
+++ b/reproducers/CMakeLists.txt
@@ -13,16 +13,18 @@ if (ENABLE_CUDA)
 endif()
 
 if (ENABLE_HIP)
-  list(APPEND care_depends hip)
+   list(APPEND care_depends hip)
 endif ()
 
 if (ENABLE_OPENMP)
    list(APPEND care_depends openmp)
 endif()
 
-blt_add_executable(NAME ReproducerManagedPtr
-                   SOURCES ReproducerManagedPtr.cpp
-                   DEPENDS_ON ${care_depends})
+if (CARE_ENABLE_MANAGED_PTR)
+   blt_add_executable(NAME ReproducerManagedPtr
+                      SOURCES ReproducerManagedPtr.cpp
+                      DEPENDS_ON ${care_depends})
 
-target_include_directories(ReproducerManagedPtr PRIVATE ${PROJECT_SOURCE_DIR}/src)
-target_include_directories(ReproducerManagedPtr PRIVATE ${PROJECT_BINARY_DIR}/include)
+   target_include_directories(ReproducerManagedPtr PRIVATE ${PROJECT_SOURCE_DIR}/src)
+   target_include_directories(ReproducerManagedPtr PRIVATE ${PROJECT_BINARY_DIR}/include)
+endif ()

--- a/src/care/PointerTypes.h
+++ b/src/care/PointerTypes.h
@@ -27,7 +27,10 @@
 // CHAI headers
 #include "chai/config.hpp"
 #include "chai/ManagedArray.hpp"
+
+#if defined(CARE_ENABLE_MANAGED_PTR)
 #include "chai/managed_ptr.hpp"
+#endif // defined(CARE_ENABLE_MANAGED_PTR)
 
 // Std library headers
 #include <cstring>
@@ -38,6 +41,8 @@
 
 namespace care{
    using CARECopyable = chai::CHAICopyable;
+
+#if defined(CARE_ENABLE_MANAGED_PTR)
 
    template <typename T>
    using managed_ptr = chai::managed_ptr<T>;
@@ -54,6 +59,8 @@ namespace care{
    inline managed_ptr<T> make_managed_from_factory(F&& f, Args&&... args) {
       return chai::make_managed_from_factory<T>(std::forward<F>(f), std::forward<Args>(args)...);
    }
+
+#endif // defined(CARE_ENABLE_MANAGED_PTR)
 }
 
 #endif // !defined(_CARE_CHAI_INTERFACE_H_)

--- a/src/care/array_utils.h
+++ b/src/care/array_utils.h
@@ -186,11 +186,6 @@ CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<const T>& array, c
                                   const char* name, const char* argname,
                                   const bool allowDuplicates = false);
 
-template <typename T>
-CARE_HOST_DEVICE bool checkSorted(const chai::managed_ptr<const T>& array, const int len,
-                                  const char* name, const char* argname,
-                                  const bool allowDuplicates = false);
-
 #if defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 
 template <typename T>
@@ -254,14 +249,6 @@ CARE_HOST_DEVICE bool checkSorted(const T* array, const int len,
 
 template <typename T>
 CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<const T>& array, const int len,
-                                  const char* name, const char* argname,
-                                  const bool allowDuplicates)
-{
-   return checkSorted<const T>(array.data(), len, name, argname, allowDuplicates);
-}
-
-template <typename T>
-CARE_HOST_DEVICE bool checkSorted(const chai::managed_ptr<const T>&& array, const int len,
                                   const char* name, const char* argname,
                                   const bool allowDuplicates)
 {

--- a/src/care/config.h.in
+++ b/src/care/config.h.in
@@ -13,6 +13,7 @@
 #cmakedefine CARE_DEBUG
 #cmakedefine01 CARE_ENABLE_GPU_SIMULATION_MODE
 #cmakedefine CARE_ENABLE_IMPLICIT_CONVERSIONS
+#cmakedefine CARE_ENABLE_MANAGED_PTR
 
 // Optional dependencies
 #cmakedefine01 CARE_HAVE_CUB

--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -438,6 +438,7 @@ namespace care {
    void using_host_device_ptr_outside_of_raja_loop_not_allowed(T foo); 
 } // namespace care
 
+#if defined(CARE_ENABLE_MANAGED_PTR)
 #if !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
 
 // TODO: Declaring these functions causes problems with a project that depends on CARE
@@ -472,6 +473,7 @@ namespace chai {
 } // namespace chai
 
 #endif // !defined(CARE_ENABLE_IMPLICIT_CONVERSIONS)
+#endif // defined(CARE_ENABLE_MANAGED_PTR)
 
 #endif // !defined(_CARE_HOST_DEVICE_PTR_H_)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,18 +84,20 @@ target_include_directories(TestKeyValueSorter
 blt_add_test( NAME TestKeyValueSorter
               COMMAND TestKeyValueSorter )
 
-blt_add_executable( NAME TestManagedPtr
-                    SOURCES TestManagedPtr.cpp
-                    DEPENDS_ON ${care_test_dependencies} )
+if (CARE_ENABLE_MANAGED_PTR)
+   blt_add_executable( NAME TestManagedPtr
+                       SOURCES TestManagedPtr.cpp
+                       DEPENDS_ON ${care_test_dependencies} )
 
-target_include_directories(TestManagedPtr
-                           PRIVATE ${PROJECT_SOURCE_DIR}/src)
+   target_include_directories(TestManagedPtr
+                              PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
-target_include_directories(TestManagedPtr
-                           PRIVATE ${PROJECT_BINARY_DIR}/include)
+   target_include_directories(TestManagedPtr
+                              PRIVATE ${PROJECT_BINARY_DIR}/include)
 
-blt_add_test( NAME TestManagedPtr
-              COMMAND TestManagedPtr )
+   blt_add_test( NAME TestManagedPtr
+                 COMMAND TestManagedPtr )
+endif()
 
 blt_add_executable( NAME TestNumeric
                     SOURCES TestNumeric.cpp


### PR DESCRIPTION
Virtual functions are not support in HIP device calls, so managed_ptr must be disabled.