### PR TITLE
Fixes inconsistent requirements in IntersectArrays

### DIFF
--- a/src/care/algorithm.h
+++ b/src/care/algorithm.h
@@ -213,11 +213,12 @@ CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<mapType>& map, con
                                   const int mapSize, const mapType num,
                                   bool returnUpperBound = false) ;
 
-inline void IntersectArrays(Exec, //!< execution policy [input]
-                            care::host_device_ptr<const ArrayType> arr1, //!< first array to intersect [input]
+template <typename T, typename ExecutionPolicy>
+inline void IntersectArrays(ExecutionPolicy, //!< execution policy [input]
+                            care::host_device_ptr<const T> arr1, //!< first array to intersect [input]
                             int size1, //!< size of segment to intersect in arr1 [input]
                             int start1, //!< starting offset of segment in arr1 [input]
-                            care::host_device_ptr<const ArrayType> arr2, //!< second array to intersect [input]
+                            care::host_device_ptr<const T> arr2, //!< second array to intersect [input]
                             int size2, //!< size of segment to intersect in arr2 [input]
                             int start2, //!< starting offset of segment in arr2 [input]
                             care::host_device_ptr<int> &matches1, //!< indices of matches in arr1 (0 corresponds to start1) [output]

--- a/src/care/algorithm.h
+++ b/src/care/algorithm.h
@@ -213,12 +213,16 @@ CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<mapType>& map, con
                                   const int mapSize, const mapType num,
                                   bool returnUpperBound = false) ;
 
-template <typename ArrayType, typename Exec>
-inline void IntersectArrays(Exec,
-                            care::host_device_ptr<const ArrayType> arr1, int size1, int start1,
-                            care::host_device_ptr<const ArrayType> arr2, int size2, int start2,
-                            care::host_device_ptr<int> &matches1, care::host_device_ptr<int> &matches2,
-                            int *numMatches);
+inline void IntersectArrays(Exec, //!< execution policy [input]
+                            care::host_device_ptr<const ArrayType> arr1, //!< first array to intersect [input]
+                            int size1, //!< size of segment to intersect in arr1 [input]
+                            int start1, //!< starting offset of segment in arr1 [input]
+                            care::host_device_ptr<const ArrayType> arr2, //!< second array to intersect [input]
+                            int size2, //!< size of segment to intersect in arr2 [input]
+                            int start2, //!< starting offset of segment in arr2 [input]
+                            care::host_device_ptr<int> &matches1, //!< indices of matches in arr1 (0 corresponds to start1) [output]
+                            care::host_device_ptr<int> &matches2, //!< indices of matches in arr2 (0 corresponds to start2) [output]
+                            int *numMatches); //!< number of matches [output]
 
 #if defined(CARE_GPUCC)
 

--- a/src/care/algorithm.inl
+++ b/src/care/algorithm.inl
@@ -105,7 +105,7 @@ inline void IntersectArrays(RAJAExec,
    *numMatches = 0 ;
    int smaller = (size1 < size2) ? size1 : size2 ;
 
-   if (smaller <= 0 || start1 >= size1 || start2 >= size2) {
+   if (smaller <= 0) {
       matches1 = nullptr ;
       matches2 = nullptr ;
       return ;
@@ -234,7 +234,7 @@ inline void IntersectArrays(RAJA::seq_exec,
    *numMatches = 0 ;
    int smaller = (size1 < size2) ? size1 : size2 ;
 
-   if (smaller <= 0 || start1 >= size1 || start2 >= size2) {
+   if (smaller <= 0) {
       matches1 = nullptr ;
       matches2 = nullptr ;
       return ;

--- a/src/care/algorithm.inl
+++ b/src/care/algorithm.inl
@@ -96,10 +96,10 @@ CARE_HOST_DEVICE bool checkSorted(const care::host_device_ptr<T>& array,
  *             start1=0, then matches1 will contain 2. However, if start1 was 1, then matches will contain 2-start1=1.
  ************************************************************************/
 #ifdef RAJA_PARALLEL_ACTIVE
-template <typename ArrayType>
+template <typename T>
 inline void IntersectArrays(RAJAExec,
-                            care::host_device_ptr<const ArrayType> arr1, int size1, int start1,
-                            care::host_device_ptr<const ArrayType> arr2, int size2, int start2,
+                            care::host_device_ptr<const T> arr1, int size1, int start1,
+                            care::host_device_ptr<const T> arr2, int size2, int start2,
                             care::host_device_ptr<int> &matches1, care::host_device_ptr<int> &matches2,
                             int *numMatches) {
    *numMatches = 0 ;
@@ -126,16 +126,16 @@ inline void IntersectArrays(RAJAExec,
       const char* funcname = "IntersectArrays" ;
 
       // allowDuplicates is false for these checks by default.
-      care::host_device_ptr<const ArrayType> slice1(arr1.slice(start1));
-      care::host_device_ptr<const ArrayType> slice2(arr2.slice(start2));
+      care::host_device_ptr<const T> slice1(arr1.slice(start1));
+      care::host_device_ptr<const T> slice2(arr2.slice(start2));
 
-      checkSorted<ArrayType>(slice1, size1, funcname, "arr1") ;
-      checkSorted<ArrayType>(slice2, size2, funcname, "arr2") ;
+      checkSorted<T>(slice1, size1, funcname, "arr1") ;
+      checkSorted<T>(slice2, size2, funcname, "arr2") ;
    }
 
    care::host_device_ptr<int> smallerMatches, largerMatches;
    int larger, smallStart, largeStart;
-   care::host_device_ptr<const ArrayType> smallerArray, largerArray;
+   care::host_device_ptr<const T> smallerArray, largerArray;
 
    if (smaller == size1) {
       smallerArray = arr1;
@@ -161,7 +161,7 @@ inline void IntersectArrays(RAJAExec,
    care::host_device_ptr<int> matched(smaller + 1, "IntersectArrays matched");
 
    CARE_STREAM_LOOP(i, 0, smaller + 1) {
-      searches[i] = i != smaller ? BinarySearch<ArrayType>(largerArray, largeStart, larger, smallerArray[i + smallStart]) : -1;
+      searches[i] = i != smaller ? BinarySearch<T>(largerArray, largeStart, larger, smallerArray[i + smallStart]) : -1;
       matched[i] = i != smaller && searches[i] > -1;
    } CARE_STREAM_LOOP_END
 
@@ -196,15 +196,15 @@ inline void IntersectArrays(RAJAExec,
    }
 }
 
-template <typename ArrayType>
+template <typename T>
 inline void IntersectArrays(RAJAExec exec,
-                            care::host_device_ptr<ArrayType> arr1, int size1, int start1,
-                            care::host_device_ptr<ArrayType> arr2, int size2, int start2,
+                            care::host_device_ptr<T> arr1, int size1, int start1,
+                            care::host_device_ptr<T> arr2, int size2, int start2,
                             care::host_device_ptr<int> &matches1, care::host_device_ptr<int> &matches2,
                             int *numMatches) {
-   IntersectArrays<ArrayType>(exec,
-                              care::host_device_ptr<const ArrayType>(arr1), size1, start1,
-                              care::host_device_ptr<const ArrayType>(arr2), size2, start2,
+   IntersectArrays<T>(exec,
+                              care::host_device_ptr<const T>(arr1), size1, start1,
+                              care::host_device_ptr<const T>(arr2), size2, start2,
                               matches1, matches2,
                               numMatches);
 }
@@ -225,10 +225,10 @@ inline void IntersectArrays(RAJAExec exec,
  * Note      : The raw pointers contained in matches1 and matches2
  *             should be deallocated by the caller using free.
  ************************************************************************/
-template <typename ArrayType>
+template <typename T>
 inline void IntersectArrays(RAJA::seq_exec,
-                            care::host_ptr<const ArrayType> arr1, int size1, int start1,
-                            care::host_ptr<const ArrayType> arr2, int size2, int start2,
+                            care::host_ptr<const T> arr1, int size1, int start1,
+                            care::host_ptr<const T> arr2, int size2, int start2,
                             care::host_ptr<int> &matches1, care::host_ptr<int> &matches2,
                             int *numMatches) {
    *numMatches = 0 ;
@@ -255,15 +255,15 @@ inline void IntersectArrays(RAJA::seq_exec,
       const char* funcname = "IntersectArrays" ;
 
       // allowDuplicates is false for this check by default
-      checkSorted<ArrayType>(&arr1[start1], size1, funcname, "arr1") ;
-      checkSorted<ArrayType>(&arr2[start2], size2, funcname, "arr2") ;
+      checkSorted<T>(&arr1[start1], size1, funcname, "arr1") ;
+      checkSorted<T>(&arr2[start2], size2, funcname, "arr2") ;
    }
 
    int i, j;
    i = j = 0 ;
 
    /* the host arrays */
-   const ArrayType * A1, *A2;
+   const T * A1, *A2;
    int * m1 = matches1;
    int * m2 = matches2;
 
@@ -301,15 +301,15 @@ inline void IntersectArrays(RAJA::seq_exec,
    }
 }
 
-template <typename ArrayType>
+template <typename T>
 inline void IntersectArrays(RAJA::seq_exec exec,
-                            care::host_ptr<ArrayType> arr1, int size1, int start1,
-                            care::host_ptr<ArrayType> arr2, int size2, int start2,
+                            care::host_ptr<T> arr1, int size1, int start1,
+                            care::host_ptr<T> arr2, int size2, int start2,
                             care::host_ptr<int> &matches1, care::host_ptr<int> &matches2,
                             int *numMatches) {
-   IntersectArrays<ArrayType>(exec,
-                              care::host_ptr<const ArrayType>(arr1), size1, start1,
-                              care::host_ptr<const ArrayType>(arr2), size2, start2,
+   IntersectArrays<T>(exec,
+                              care::host_ptr<const T>(arr1), size1, start1,
+                              care::host_ptr<const T>(arr2), size2, start2,
                               matches1, matches2, numMatches);
 }
 
@@ -325,17 +325,17 @@ inline void IntersectArrays(RAJA::seq_exec exec,
  * Note      : matches are given as offsets from start1 and start2. So, if a match occurs at arr1[2] with
  *             start1=0, then matches1 will contain 2. However, if start1 was 1, then matches will contain 2-start1=1.
  ************************************************************************/
-template <typename ArrayType>
+template <typename T>
 inline void IntersectArrays(RAJA::seq_exec exec,
-                            care::host_device_ptr<const ArrayType> arr1, int size1, int start1,
-                            care::host_device_ptr<const ArrayType> arr2, int size2, int start2,
+                            care::host_device_ptr<const T> arr1, int size1, int start1,
+                            care::host_device_ptr<const T> arr2, int size2, int start2,
                             care::host_device_ptr<int> &matches1, care::host_device_ptr<int> &matches2,
                             int *numMatches) {
    care::host_ptr<int> matches1_tmp, matches2_tmp;
 
-   IntersectArrays<ArrayType>(exec,
-                              care::host_ptr<const ArrayType>(arr1), size1, start1,
-                              care::host_ptr<const ArrayType>(arr2), size2, start2,
+   IntersectArrays<T>(exec,
+                              care::host_ptr<const T>(arr1), size1, start1,
+                              care::host_ptr<const T>(arr2), size2, start2,
                               matches1_tmp, matches2_tmp, numMatches);
 
    matches1 = care::host_device_ptr<int>((int *) matches1_tmp, *numMatches, "IntersectArrays matches1");
@@ -344,15 +344,15 @@ inline void IntersectArrays(RAJA::seq_exec exec,
    return;
 }
 
-template <typename ArrayType>
+template <typename T>
 inline void IntersectArrays(RAJA::seq_exec exec,
-                            care::host_device_ptr<ArrayType> arr1, int size1, int start1,
-                            care::host_device_ptr<ArrayType> arr2, int size2, int start2,
+                            care::host_device_ptr<T> arr1, int size1, int start1,
+                            care::host_device_ptr<T> arr2, int size2, int start2,
                             care::host_device_ptr<int> &matches1, care::host_device_ptr<int> &matches2,
                             int *numMatches) {
    IntersectArrays(exec,
-                   care::host_device_ptr<const ArrayType>(arr1), size1, start1,
-                   care::host_device_ptr<const ArrayType>(arr2), size2, start2,
+                   care::host_device_ptr<const T>(arr1), size1, start1,
+                   care::host_device_ptr<const T>(arr2), size2, start2,
                    matches1, matches2, numMatches);
 }
 

--- a/test/TestAlgorithm.cpp
+++ b/test/TestAlgorithm.cpp
@@ -160,7 +160,7 @@ TEST(algorithm, intersectarrays) {
 
    // introduce non-zero starting locations. In this case, matches are given as offsets from those starting locations
    // and not the zero position of the arrays.
-   care::IntersectArrays<int>(RAJA::seq_exec(), c, 7, 3, b, 5, 1, matches1, matches2, numMatches);
+   care::IntersectArrays<int>(RAJA::seq_exec(), c, 4, 3, b, 4, 1, matches1, matches2, numMatches);
    EXPECT_EQ(numMatches[0], 2); 
    EXPECT_EQ(matches1[0], 0);
    EXPECT_EQ(matches1[1], 1);
@@ -174,10 +174,6 @@ TEST(algorithm, intersectarrays) {
    EXPECT_EQ(matches1[1], 2);
    EXPECT_EQ(matches2[0], 0);
    EXPECT_EQ(matches2[1], 3); 
-
-   // offset one past the end
-   care::IntersectArrays<int>(RAJA::seq_exec(), a, 3, 0, b, 5, 98, matches1, matches2, numMatches);
-   EXPECT_EQ(numMatches[0], 0);
 
    // no matches
    care::IntersectArrays<int>(RAJA::seq_exec(), a, 3, 0, d, 9, 0, matches1, matches2, numMatches);
@@ -1188,7 +1184,7 @@ GPU_TEST(algorithm, intersectarrays) {
 
    // introduce non-zero starting locations. In this case, matches are given as offsets from those starting locations
    // and not the zero position of the arrays.
-   care::IntersectArrays<int>(RAJAExec(), c, 7, 3, b, 5, 1, matches1, matches2, numMatches);
+   care::IntersectArrays<int>(RAJAExec(), c, 4, 3, b, 4, 1, matches1, matches2, numMatches);
    EXPECT_EQ(numMatches[0], 2);
    EXPECT_EQ(matches1.pick(0), 0);
    EXPECT_EQ(matches1.pick(1), 1);
@@ -1202,10 +1198,6 @@ GPU_TEST(algorithm, intersectarrays) {
    EXPECT_EQ(matches1.pick(1), 2);
    EXPECT_EQ(matches2.pick(0), 0);
    EXPECT_EQ(matches2.pick(1), 3);
-
-   // offset one past the end
-   care::IntersectArrays<int>(RAJAExec(), a, 3, 0, b, 5, 98, matches1, matches2, numMatches);
-   EXPECT_EQ(numMatches[0], 0);
 
    // no matches
    care::IntersectArrays<int>(RAJAExec(), a, 3, 0, d, 9, 0, matches1, matches2, numMatches);


### PR DESCRIPTION
These fixes are courtesy of Ben Liu. The parameters of IntersectArrays are now correctly documented. What once was inconsistently considered the size of an array is now treated as the length of the array segment under consideration. The tests are updated to fit with these clarified specifications.