### PR TITLE
Adds run time selectable policies for forall

### DIFF
--- a/src/care/forall.h
+++ b/src/care/forall.h
@@ -347,6 +347,55 @@ namespace care {
       }
 #endif
    }
+
+   ////////////////////////////////////////////////////////////////////////////////
+   ///
+   /// @author Alan Dayton
+   ///
+   /// @brief Execute on the host. This specialization is needed for clang-query.
+   ///
+   /// @arg[in] sequential Used to choose this overload of forall
+   /// @arg[in] fileName The name of the file where this function is called
+   /// @arg[in] lineNumber The line number in the file where this function is called
+   /// @arg[in] start The starting index (inclusive)
+   /// @arg[in] end The ending index (exclusive)
+   /// @arg[in] body The loop body to execute at each index
+   ///
+   ////////////////////////////////////////////////////////////////////////////////
+   template <typename LB>
+   void forall(Policy&& policy, const char * fileName, const int lineNumber,
+               const int start, const int end, LB&& body) {
+      switch (policy) {
+         case Policy::sequential:
+            forall(sequential{}, fileName, lineNumber, start, end, body);
+            break;
+         case Policy::openmp:
+            forall(openmp{}, fileName, lineNumber, start, end, body);
+            break;
+         case Policy::gpu:
+            forall(gpu{}, fileName, lineNumber, start, end, body);
+            break;
+         case Policy::parallel:
+            forall(parallel{}, fileName, lineNumber, start, end, body);
+            break;
+         case Policy::raja_fusible:
+            forall(raja_fusible{}, fileName, lineNumber, start, end, body);
+            break;
+         case Policy::raja_fusible_seq:
+            forall(raja_fusible_seq{}, fileName, lineNumber, start, end, body);
+            break;
+         case Policy::raja_chai_everywhere:
+            forall(raja_chai_everywhere{}, fileName, lineNumber, start, end, body);
+            break;
+         case Policy::gpu_simulation:
+            forall(gpu_simulation{}, fileName, lineNumber, start, end, body);
+            break;
+         default:
+            std::cout << "[CARE] Error: Invalid policy!" << std::endl;
+            std::abort();
+            break;
+      }
+   }
 } // namespace care
 
 #endif // !defined(_CARE_FORALL_H_)

--- a/src/care/forall.h
+++ b/src/care/forall.h
@@ -378,17 +378,8 @@ namespace care {
          case Policy::parallel:
             forall(parallel{}, fileName, lineNumber, start, end, body);
             break;
-         case Policy::raja_fusible:
-            forall(raja_fusible{}, fileName, lineNumber, start, end, body);
-            break;
-         case Policy::raja_fusible_seq:
-            forall(raja_fusible_seq{}, fileName, lineNumber, start, end, body);
-            break;
          case Policy::raja_chai_everywhere:
             forall(raja_chai_everywhere{}, fileName, lineNumber, start, end, body);
-            break;
-         case Policy::gpu_simulation:
-            forall(gpu_simulation{}, fileName, lineNumber, start, end, body);
             break;
          default:
             std::cout << "[CARE] Error: Invalid policy!" << std::endl;

--- a/src/care/forall.h
+++ b/src/care/forall.h
@@ -352,9 +352,10 @@ namespace care {
    ///
    /// @author Alan Dayton
    ///
-   /// @brief Execute on the host. This specialization is needed for clang-query.
+   /// @brief Loops over the given indices and calls the loop body with each index.
+   ///        This overload takes a run time selectable policy.
    ///
-   /// @arg[in] sequential Used to choose this overload of forall
+   /// @arg[in] policy Run time policy used to select the backend to execute on.
    /// @arg[in] fileName The name of the file where this function is called
    /// @arg[in] lineNumber The line number in the file where this function is called
    /// @arg[in] start The starting index (inclusive)

--- a/src/care/policies.h
+++ b/src/care/policies.h
@@ -26,10 +26,7 @@ namespace care {
       openmp,
       gpu,
       parallel,
-      raja_fusible,
-      raja_fusible_seq,
-      raja_chai_everywhere,
-      gpu_simulation
+      raja_chai_everywhere
    };
 } // namespace care
 

--- a/src/care/policies.h
+++ b/src/care/policies.h
@@ -19,6 +19,18 @@ namespace care {
    struct raja_fusible_seq {};
    struct raja_chai_everywhere {};
    struct gpu_simulation {};
+
+   enum class Policy {
+      none = -1,
+      sequential,
+      openmp,
+      gpu,
+      parallel,
+      raja_fusible,
+      raja_fusible_seq,
+      raja_chai_everywhere,
+      gpu_simulation
+   };
 } // namespace care
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,19 @@ if (ENABLE_OPENMP)
    set (care_test_dependencies ${care_test_dependencies} openmp)
 endif()
 
+blt_add_executable( NAME TestForall
+                    SOURCES TestForall.cpp
+                    DEPENDS_ON ${care_test_dependencies} )
+
+target_include_directories(TestForall
+                           PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
+target_include_directories(TestForall
+                           PRIVATE ${PROJECT_BINARY_DIR}/include)
+
+blt_add_test( NAME TestForall
+              COMMAND TestForall )
+
 blt_add_executable( NAME TestLoopFuser
                     SOURCES LoopFuserTest.cxx
                     DEPENDS_ON ${care_test_dependencies} )

--- a/test/TestForall.cpp
+++ b/test/TestForall.cpp
@@ -1,0 +1,95 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// Copyright 2020 Lawrence Livermore National Security, LLC and other CARE developers.
+// See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "care/config.h"
+
+// Makes CARE_REDUCE_LOOP run on the device
+#if defined(CARE_GPUCC)
+#define GPU_ACTIVE
+#endif
+
+// other library headers
+#include "gtest/gtest.h"
+
+// care headers
+#include "care/DefaultMacros.h"
+#include "care/host_device_ptr.h"
+
+TEST(forall, static_policy)
+{
+   const int length = 10;
+   care::host_device_ptr<int> temp(length, "temp");
+
+   CARE_LOOP(care::sequential{}, i, 0, length) {
+      temp[i] = i;
+   } CARE_LOOP_END
+
+   CARE_SEQUENTIAL_LOOP(i, 0, length) {
+      EXPECT_EQ(temp[i], i);
+   } CARE_SEQUENTIAL_LOOP_END
+
+   temp.free();
+}
+
+TEST(forall, dynamic_policy)
+{
+   const int length = 10;
+   care::host_device_ptr<int> temp(length, "temp");
+
+   CARE_LOOP(care::Policy::sequential, i, 0, length) {
+      temp[i] = i;
+   } CARE_LOOP_END
+
+   CARE_SEQUENTIAL_LOOP(i, 0, length) {
+      EXPECT_EQ(temp[i], i);
+   } CARE_SEQUENTIAL_LOOP_END
+
+   temp.free();
+}
+
+#if defined(CARE_GPUCC)
+
+// Adapted from CHAI
+#define GPU_TEST(X, Y) \
+   static void gpu_test_##X##Y(); \
+   TEST(X, gpu_test_##Y) { gpu_test_##X##Y(); } \
+   static void gpu_test_##X##Y()
+
+GPU_TEST(forall, static_policy)
+{
+   const int length = 10;
+   care::host_device_ptr<int> temp(length, "temp");
+
+   CARE_LOOP(care::gpu{}, i, 0, length) {
+      temp[i] = i;
+   } CARE_LOOP_END
+
+   CARE_SEQUENTIAL_LOOP(i, 0, length) {
+      EXPECT_EQ(temp[i], i);
+   } CARE_SEQUENTIAL_LOOP_END
+
+   temp.free();
+}
+
+GPU_TEST(forall, dynamic_policy)
+{
+   const int length = 10;
+   care::host_device_ptr<int> temp(length, "temp");
+
+   CARE_LOOP(care::Policy::gpu, i, 0, length) {
+      temp[i] = i;
+   } CARE_LOOP_END
+
+   CARE_SEQUENTIAL_LOOP(i, 0, length) {
+      EXPECT_EQ(temp[i], i);
+   } CARE_SEQUENTIAL_LOOP_END
+
+   temp.free();
+}
+
+#endif // CARE_GPUCC
+

--- a/test/TestForall.cpp
+++ b/test/TestForall.cpp
@@ -19,7 +19,13 @@
 #include "care/DefaultMacros.h"
 #include "care/host_device_ptr.h"
 
-TEST(forall, static_policy)
+// Adapted from CHAI
+#define CPU_TEST(X, Y) \
+   static void cpu_test_##X##Y(); \
+   TEST(X, cpu_test_##Y) { cpu_test_##X##Y(); } \
+   static void cpu_test_##X##Y()
+
+CPU_TEST(forall, static_policy)
 {
    const int length = 10;
    care::host_device_ptr<int> temp(length, "temp");
@@ -35,7 +41,7 @@ TEST(forall, static_policy)
    temp.free();
 }
 
-TEST(forall, dynamic_policy)
+CPU_TEST(forall, dynamic_policy)
 {
    const int length = 10;
    care::host_device_ptr<int> temp(length, "temp");


### PR DESCRIPTION
- Adds an enum with a limited number of run time selectable policies
- Adds an overload of forall that takes this enum as an argument
- Uses the existing CARE_LOOP as a mechanism for calling the new overload of forall (also works with the compile time policies)
- CARE_LOOP uses CARE_HOST_DEVICE for the lambda, which means if CUDA or HIP is enabled these lambdas are always extended `__host__ __device__` lambdas (no dependency on GPU_ACTIVE). Otherwise they are always on the host only.