### PR TITLE
Remove troublesome uses of GPU_ACTIVE

### DIFF
--- a/src/care/CHAIDataGetter.h
+++ b/src/care/CHAIDataGetter.h
@@ -32,7 +32,7 @@ class CHAIDataGetter {
       static const auto ChaiPolicy = chai::CPU;
 };
 
-#if defined(CARE_GPUCC) && defined(GPU_ACTIVE)
+#if defined(CARE_GPUCC)
 
 // Partial specialization of CHAIDataGetter for cuda_exec.
 template <typename T>
@@ -52,7 +52,7 @@ class CHAIDataGetter<T, RAJADeviceExec> {
 
 /* specialization for globalID */
 template <>
-class CHAIDataGetter<globalID, RAJACudaExec> {
+class CHAIDataGetter<globalID, RAJADeviceExec> {
    public:
       typedef GIDTYPE raw_type;
       GIDTYPE * getRawArrayData(chai::ManagedArray<globalID> data) {
@@ -66,6 +66,6 @@ class CHAIDataGetter<globalID, RAJACudaExec> {
 
 #endif // CARE_HAVE_LLNL_GLOBALID
 
-#endif // CARE_GPUCC && GPU_ACTIVE
+#endif // CARE_GPUCC
 
 #endif // !defined(_CARE_CHAI_DATA_GETTER_H_)

--- a/src/care/forall.h
+++ b/src/care/forall.h
@@ -153,7 +153,7 @@ namespace care {
 #elif defined(GPU_ACTIVE) && defined(__CUDACC__)
       forall(RAJA::cuda_exec<CARE_CUDA_BLOCK_SIZE, CARE_CUDA_ASYNC>{},
              fileName, lineNumber, start, end, body);
-#elif  defined(GPU_ACTIVE) && defined(__HIPCC__)
+#elif defined(GPU_ACTIVE) && defined(__HIPCC__)
       forall(RAJA::hip_exec<CARE_CUDA_BLOCK_SIZE, CARE_CUDA_ASYNC>{},
              fileName, lineNumber, start, end, body);
 #else
@@ -229,7 +229,7 @@ namespace care {
       }
    }
 
-#if defined CARE_GPUCC && defined GPU_ACTIVE
+#if defined(CARE_GPUCC)
 
    ////////////////////////////////////////////////////////////////////////////////
    ///


### PR DESCRIPTION
I ran into a case where the cub sort was failing to compile because the globalID array was not being converted to a GIDTYPE array.