### PR TITLE
rename CUDAWatchpoint to GPUWatchpoint, fix header include

### DIFF
--- a/src/care/CMakeLists.txt
+++ b/src/care/CMakeLists.txt
@@ -23,7 +23,7 @@ set(care_headers
     atomic.h
     CHAICallback.h
     CHAIDataGetter.h
-    CUDAWatchpoint.h
+    GPUWatchpoint.h
     Debug.h
     DefaultMacros.h
     device_ptr.h

--- a/src/care/GPUWatchpoint.h
+++ b/src/care/GPUWatchpoint.h
@@ -6,7 +6,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #ifndef _CARE_CUDA_WATCHPOINT_H_
-#define _CARE_CUDA_WATCHPOINT_H_
+#define _CARE_GPU_WATCHPOINT_H_
 
 #ifdef CARE_DEBUG
 #if defined(CARE_GPUCC)
@@ -34,7 +34,7 @@ inline void watchpoint_gpuAssert(care_watchpoint_err_t code, const char *file, i
    }
 }
 
-class CUDAWatchpoint {
+class GPUWatchpoint {
    public:
       template <typename T>
       static void setOrCheckWatchpoint(T * deviceAddress = nullptr) {
@@ -45,12 +45,12 @@ class CUDAWatchpoint {
             if (wp) {
                T currentVal;
 #if defined(__CUDACC__)
-               watchpoint_gpuAssert(cudaMemcpy(&currentVal, (void *) wp, sizeof(T), cudaMemcpyDeviceToHost), "CUDAWatchpoint", __LINE__, true);
+               watchpoint_gpuAssert(cudaMemcpy(&currentVal, (void *) wp, sizeof(T), cudaMemcpyDeviceToHost), "GPUWatchpoint", __LINE__, true);
 #elif defined(__HIPCC__)
-               watchpoint_gpuAssert(hipMemcpy(&currentVal, (void *) wp, sizeof(T),  hipMemcpyDeviceToHost), "CUDAWatchpoint", __LINE__, true);
+               watchpoint_gpuAssert(hipMemcpy(&currentVal, (void *) wp, sizeof(T),  hipMemcpyDeviceToHost), "GPUWatchpoint", __LINE__, true);
 #endif               
                if (currentVal != oldVal) {
-                  printf("[CARE] CUDA Watchpoint %p change detected!\n", wp);
+                  printf("[CARE] GPU Watchpoint %p change detected!\n", wp);
                   oldVal = currentVal;
                }
             }
@@ -59,9 +59,9 @@ class CUDAWatchpoint {
          else {
             wp = deviceAddress;
 #if defined(__CUDACC__)
-            watchpoint_gpuAssert(cudaMemcpy(&oldVal, (void *) wp, sizeof(T), cudaMemcpyDeviceToHost), "CUDAWatchpoint", __LINE__, true);
+            watchpoint_gpuAssert(cudaMemcpy(&oldVal, (void *) wp, sizeof(T), cudaMemcpyDeviceToHost), "GPUWatchpoint", __LINE__, true);
 #elif defined(__HIPCC__)
-            watchpoint_gpuAssert(hipMemcpy(&oldVal, (void *) wp, sizeof(T),  hipMemcpyDeviceToHost), "CUDAWatchpoint", __LINE__, true);
+            watchpoint_gpuAssert(hipMemcpy(&oldVal, (void *) wp, sizeof(T),  hipMemcpyDeviceToHost), "GPUWatchpoint", __LINE__, true);
 #endif         
          }
       }
@@ -70,4 +70,4 @@ class CUDAWatchpoint {
 #endif //CARE_GPUCC
 #endif //CARE_DEBUG
 
-#endif // !defined(_CARE_CUDA_WATCHPOINT_H_)
+#endif // !defined(_CARE_GPU_WATCHPOINT_H_)

--- a/src/care/RAJAPlugin.cpp
+++ b/src/care/RAJAPlugin.cpp
@@ -64,7 +64,7 @@ namespace care {
          s_active_pointers_in_loop.clear();
 
 #if defined(CARE_GPUCC) && defined(CARE_DEBUG)
-         CUDAWatchpoint::setOrCheckWatchpoint<int>();
+         GPUWatchpoint::setOrCheckWatchpoint<int>();
 #endif // defined(CARE_GPUCC) && defined(CARE_DEBUG)
       }
 #endif // !defined(CHAI_DISABLE_RM)
@@ -208,7 +208,7 @@ namespace care {
          s_active_pointers_in_loop.clear();
 
 #if defined(CARE_GPUCC) && defined(CARE_DEBUG)
-         CUDAWatchpoint::setOrCheckWatchpoint<int>();
+         GPUWatchpoint::setOrCheckWatchpoint<int>();
 #endif // defined(CARE_GPUCC) && defined(CARE_DEBUG)
       }
 

--- a/src/care/care.h
+++ b/src/care/care.h
@@ -13,7 +13,7 @@
 
 // Other CARE headers
 #include "care/CHAICallback.h"
-#include "care/CUDAWatchpoint.h"
+#include "care/GPUWatchpoint.h"
 #include "care/DefaultMacros.h"
 #include "care/FOREACHMACRO.h"
 #include "care/PointerTypes.h"

--- a/src/care/util.h
+++ b/src/care/util.h
@@ -15,6 +15,9 @@
 // Other library headers
 #if defined(__CUDACC__)
 #include "cuda.h"
+#endif
+
+#if defined(CARE_GPUCC)
 #if defined(CARE_DEBUG)
 #include "care/CUDAWatchpoint.h"
 #endif

--- a/src/care/util.h
+++ b/src/care/util.h
@@ -19,7 +19,7 @@
 
 #if defined(CARE_GPUCC)
 #if defined(CARE_DEBUG)
-#include "care/CUDAWatchpoint.h"
+#include "care/GPUWatchpoint.h"
 #endif
 #endif
 
@@ -168,7 +168,7 @@ namespace care {
          }
       }
 #if defined(CARE_DEBUG)
-      CUDAWatchpoint::setOrCheckWatchpoint<int>();
+      GPUWatchpoint::setOrCheckWatchpoint<int>();
 #endif
    }
 
@@ -198,7 +198,7 @@ namespace care {
          }
       }
 #if defined(CARE_DEBUG)
-      CUDAWatchpoint::setOrCheckWatchpoint<int>();
+      GPUWatchpoint::setOrCheckWatchpoint<int>();
 #endif
    }
 


### PR DESCRIPTION
I need to include Cuda watch point for both the hip and cuda debug build, not just the cuda build as before

Also rename CudaWatchpoint to GPUWatchpoint