### PR TITLE
Rename and clean up ArrayCopy

### DIFF
--- a/src/care/algorithm.h
+++ b/src/care/algorithm.h
@@ -159,19 +159,13 @@ int FindIndexGT(care::host_device_ptr<const T> arr, int n, T limit);
 template <typename T, typename Exec=RAJAExec >
 care::host_device_ptr<T> ArrayDup(care::host_device_ptr<const T> from, int len);
 
-template <typename T>
-void ArrayCopy(care::host_device_ptr<T> into, care::host_device_ptr<const T> from, int n,
-               int start1=0, int start2=0);
+template <class T, class Size, class U>
+void copy_n(care::host_device_ptr<const T> src, Size count,
+            care::host_device_ptr<U> dest);
 
-template <typename T, typename Exec>
-void ArrayCopy(Exec,
-               care::host_device_ptr<T> into, care::host_device_ptr<const T> from,
-               int n, int start1=0, int start2=0);
-
-template <typename T>
-void ArrayCopy(RAJA::seq_exec,
-               care::host_device_ptr<T> into, care::host_device_ptr<const T> from,
-               int n, int start1=0, int start2=0);
+template <class T, class Size, class U>
+void copy_n(care::host_device_ptr<T> src, Size count,
+            care::host_device_ptr<U> dest);
 
 template <typename T, typename Exec=RAJAExec >
 int FindIndexMax(care::host_device_ptr<const T> arr, int n);

--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -419,7 +419,23 @@ namespace care {
       CARE_HOST void move(ExecutionSpace space) {
          MA::move(chai::ExecutionSpace((int) space));
       }
+
+      CARE_HOST_DEVICE host_device_ptr<T> slice(size_t begin, size_t elems=(size_t)-1) const {
+         return MA::slice(begin, elems);
+      }
+
+      template <class U, class V>
+      friend CARE_HOST_DEVICE host_device_ptr<U> reinterpret_pointer_cast(const host_device_ptr<V>& other) noexcept;
    }; // class host_device_ptr
+
+   template <class T, class U>
+   CARE_HOST_DEVICE host_device_ptr<T> reinterpret_pointer_cast(const host_device_ptr<U>& other) noexcept {
+#if !defined(CHAI_DISABLE_RM)
+      return chai::ManagedArray<T>(other.m_pointer_record, other.m_pointer_record->m_last_space);
+#else
+      return chai::ManagedArray<T>(other.m_pointer_record, chai::CPU);
+#endif
+   }
 
    /////////////////////////////////////////////////////////////////////////////////
    /// @author Danny Taller

--- a/test/TestAlgorithm.cpp
+++ b/test/TestAlgorithm.cpp
@@ -1698,7 +1698,7 @@ GPU_TEST(algorithm, dup_and_copy) {
   EXPECT_EQ(dupnil, nullptr);
 
   // copy and check that elements are the same
-  care::ArrayCopy<int>(to1, from, size);
+  care::copy_n(from, size, to1);
   RAJAReduceMin<bool> passed1{true};
 
   CARE_REDUCE_LOOP(i, 0, size) {
@@ -1710,7 +1710,7 @@ GPU_TEST(algorithm, dup_and_copy) {
   ASSERT_TRUE((bool) passed1);
 
   // copy 2 elements, testing different starting points
-  care::ArrayCopy<int>(to2, from, 2, 3, 4);
+  care::copy_n(from.slice(4), 2, to2.slice(3));
   RAJAReduceMin<bool> passed2{true};
 
   CARE_REDUCE_LOOP(i, 0, 1) {
@@ -1730,7 +1730,7 @@ GPU_TEST(algorithm, dup_and_copy) {
   ASSERT_TRUE((bool) passed2);
 
   // copy 2 elements, testing different starting points
-  care::ArrayCopy<int>(to3, from, 2, 4, 3);
+  care::copy_n(from.slice(3), 2, to3.slice(4));
   RAJAReduceMin<bool> passed3{true};
 
   CARE_REDUCE_LOOP(i, 0, 1) {


### PR DESCRIPTION
* Rename ArrayCopy to copy_n and make the argument order match std::copy_n
* Make the arguments to copy_n more flexible
* Add a slice method to host_device_ptr
* Update the algorithm tests for copy_n
* Add a reinterpret_pointer_cast method for reinterpreting host_device_ptr to different types