### PR TITLE
minor fix for LoopFuser with hip enabled

### DIFF
--- a/src/care/GPUMacros.h
+++ b/src/care/GPUMacros.h
@@ -50,7 +50,7 @@
 #elif defined(__HIPCC__)
 
 #define gpuStream_t hipStream_t
-#define gpuHostAllocDefault hipHostAllocDefault;
+#define gpuHostAllocDefault hipHostMallocDefault
 
 #define gpuMemcpyKind hipMemcpyKind
 #define gpuMemcpyHostToHost hipMemcpyHostToHost


### PR DESCRIPTION
cuda has the function cudaHostAlloc whereas hip prefers hipHostMalloc (note the extra M), and I am fixing that in one place.  

See also the review on spack to add this option, https://github.com/spack/spack/pull/20417 