### PR TITLE
Feature/probinso/register binning 2

### DIFF
--- a/src/care/LoopFuser.cpp
+++ b/src/care/LoopFuser.cpp
@@ -193,7 +193,7 @@ void LoopFuser<REGISTER_COUNT>::waitIfNeeded() {
 template<int REGISTER_COUNT>
 void LoopFuser<REGISTER_COUNT>::warnIfNotFlushed() {
    if (m_action_count > 0) {
-      std::cout << (void *)this<<" LoopFuser not flushed when expected." << std::endl;
+      std::cout << (void *)this<<" LoopFuser<"<< REGISTER_COUNT <<"> not flushed when expected." << std::endl;
    }
 }
 

--- a/src/care/LoopFuser.cpp
+++ b/src/care/LoopFuser.cpp
@@ -69,8 +69,8 @@ CARE_DLL_API void FusedActionsObserver::cleanupAllFusedActions() {
    allObservers.clear();
 }
 
-template<int REGISTER_COUNT>
-CARE_DLL_API LoopFuser<REGISTER_COUNT>::LoopFuser(allocator a) : FusedActions(),
+template<int REGISTER_COUNT, typename...XARGS>
+CARE_DLL_API LoopFuser<REGISTER_COUNT,XARGS...>::LoopFuser(allocator a) : FusedActions(),
    m_allocator(a),
    m_max_action_length(0),
    m_reserved(0),
@@ -78,10 +78,10 @@ CARE_DLL_API LoopFuser<REGISTER_COUNT>::LoopFuser(allocator a) : FusedActions(),
    m_action_offsets(nullptr),
    m_conditionals(a),
    m_cw(m_conditionals.instantiate()),
-   m_cws(m_cw.run(nullptr, nullptr, -1, fusible_registers{})),
+   m_cws(m_cw.run(nullptr, nullptr, -1, XARGS{}...)),
    m_actions(a),
    m_aw(m_actions.instantiate()),
-   m_aws(m_aw.run(nullptr, fusible_registers{})),
+   m_aws(m_aw.run(nullptr, XARGS{}...)),
    m_scan_type(0),
    m_scan_pos_outputs(nullptr),
    m_scan_pos_starts(nullptr),
@@ -103,25 +103,25 @@ CARE_DLL_API LoopFuser<REGISTER_COUNT>::LoopFuser(allocator a) : FusedActions(),
       reserve(10*1024);
 }
 
-template<int REGISTER_COUNT>
-CARE_DLL_API LoopFuser<REGISTER_COUNT> * LoopFuser<REGISTER_COUNT>::getInstance() {
-   static LoopFuser<REGISTER_COUNT> * instance = nullptr;
+template<int REGISTER_COUNT, typename...XARGS>
+CARE_DLL_API LoopFuser<REGISTER_COUNT,XARGS...> * LoopFuser<REGISTER_COUNT,XARGS...>::getInstance() {
+   static LoopFuser<REGISTER_COUNT,XARGS...> * instance = nullptr;
    if (instance == nullptr) {
-      instance = defaultObserver->getFusedActions<LoopFuser>(CARE_DEFAULT_PHASE);
+      instance = defaultObserver->getFusedActions<LoopFuser<REGISTER_COUNT, XARGS...>>(CARE_DEFAULT_PHASE);
    }
    return instance;
 }
 
-template<int REGISTER_COUNT>
-void LoopFuser<REGISTER_COUNT>::startRecording() {
+template<int REGISTER_COUNT, typename...XARGS>
+void LoopFuser<REGISTER_COUNT,XARGS...>::startRecording() {
    m_recording = true;  warnIfNotFlushed();
 }
 
-template<int REGISTER_COUNT>
-void LoopFuser<REGISTER_COUNT>::stopRecording() { m_recording = false;  }
+template<int REGISTER_COUNT, typename...XARGS>
+void LoopFuser<REGISTER_COUNT,XARGS...>::stopRecording() { m_recording = false;  }
 
-template<int REGISTER_COUNT>
-CARE_DLL_API LoopFuser<REGISTER_COUNT>::~LoopFuser() {
+template<int REGISTER_COUNT, typename...XARGS>
+CARE_DLL_API LoopFuser<REGISTER_COUNT,XARGS...>::~LoopFuser() {
    warnIfNotFlushed();
    if (m_reserved > 0) {
       m_allocator.deallocate((char *)m_action_offsets, m_totalsize);
@@ -132,8 +132,8 @@ CARE_DLL_API LoopFuser<REGISTER_COUNT>::~LoopFuser() {
    }
 }
 
-template<int REGISTER_COUNT>
-void LoopFuser<REGISTER_COUNT>::reserve(size_t size) {
+template<int REGISTER_COUNT, typename...XARGS>
+void LoopFuser<REGISTER_COUNT,XARGS...>::reserve(size_t size) {
    static char * pinned_buf;
    m_totalsize = size*(sizeof(int)*3);
    pinned_buf = (char *)m_allocator.allocate(m_totalsize);
@@ -150,8 +150,8 @@ void LoopFuser<REGISTER_COUNT>::reserve(size_t size) {
 
 /* resets lambda_size and m_action_count to 0, keeping our buffers
  * the same */
-template<int REGISTER_COUNT>
-void LoopFuser<REGISTER_COUNT>::reset(bool async, const char * fileName, int lineNumber) {
+template<int REGISTER_COUNT, typename...XARGS>
+void LoopFuser<REGISTER_COUNT,XARGS...>::reset(bool async, const char * fileName, int lineNumber) {
    m_action_count = 0;
    m_max_action_length = 0;
    m_prev_pos_output = nullptr;
@@ -176,8 +176,8 @@ void LoopFuser<REGISTER_COUNT>::reset(bool async, const char * fileName, int lin
 }
 
 /*ensures any previous asynchronous launch from this fuser is done before proceeding. */
-template<int REGISTER_COUNT>
-void LoopFuser<REGISTER_COUNT>::waitIfNeeded() {
+template<int REGISTER_COUNT, typename...XARGS>
+void LoopFuser<REGISTER_COUNT,XARGS...>::waitIfNeeded() {
    if (m_wait_needed) {
       // ensure asynchronous launch from previous flush is done
       m_async_resource.wait_for(&m_wait_for_event);
@@ -190,21 +190,21 @@ void LoopFuser<REGISTER_COUNT>::waitIfNeeded() {
    }
 }
 
-template<int REGISTER_COUNT>
-void LoopFuser<REGISTER_COUNT>::warnIfNotFlushed() {
+template<int REGISTER_COUNT, typename...XARGS>
+void LoopFuser<REGISTER_COUNT,XARGS...>::warnIfNotFlushed() {
    if (m_action_count > 0) {
       std::cout << (void *)this<<" LoopFuser<"<< REGISTER_COUNT <<"> not flushed when expected." << std::endl;
    }
 }
 
-template<int REGISTER_COUNT>
-void LoopFuser<REGISTER_COUNT>::flush_parallel_actions(bool async, const char * fileName, int lineNumber) {
+template<int REGISTER_COUNT, typename...XARGS>
+void LoopFuser<REGISTER_COUNT,XARGS...>::flush_parallel_actions(bool async, const char * fileName, int lineNumber) {
    // Do the thing
    if (verbose) {
       printf("in flush_parallel_actions at %s:%i with %zu, %i\n", fileName, lineNumber, m_actions.num_loops(), m_max_action_length);
    }
    m_aw = m_actions.instantiate();
-   m_aws = m_aw.run(nullptr, fusible_registers{});
+   m_aws = m_aw.run(nullptr, XARGS{}...);
    // this resets m_conditionals, which we will never need to run
    m_conditionals.clear();
    if (verbose) {
@@ -214,19 +214,19 @@ void LoopFuser<REGISTER_COUNT>::flush_parallel_actions(bool async, const char * 
 }
 
 
-template<int REGISTER_COUNT>
-void LoopFuser<REGISTER_COUNT>::flush_order_preserving_actions(bool async, const char * fileName, int  lineNumber) {
+template<int REGISTER_COUNT, typename...XARGS>
+void LoopFuser<REGISTER_COUNT,XARGS...>::flush_order_preserving_actions(bool async, const char * fileName, int  lineNumber) {
    // Do the thing
    m_aw = m_actions.instantiate();
-   m_aws = m_aw.run(nullptr, fusible_registers{});
+   m_aws = m_aw.run(nullptr, XARGS{}...);
    // this resets m_conditionals, don't run them.
    m_conditionals.clear();
    reset(async, fileName, lineNumber);
 }
 
 
-template<int REGISTER_COUNT>
-void LoopFuser<REGISTER_COUNT>::flush_parallel_scans(const char * fileName, int lineNumber) {
+template<int REGISTER_COUNT, typename...XARGS>
+void LoopFuser<REGISTER_COUNT,XARGS...>::flush_parallel_scans(const char * fileName, int lineNumber) {
    if (verbose) {
       printf("in flush_parallel_scans at %s:%i with %i,%i\n", fileName, lineNumber, m_action_count, m_max_action_length);
    }
@@ -237,7 +237,7 @@ void LoopFuser<REGISTER_COUNT>::flush_parallel_scans(const char * fileName, int 
    int action_count = m_action_count;
 
    // handle the last index by enqueuing a specialized lambda to batch with the rest.
-   m_conditionals.enqueue(RAJA::RangeSegment(0,1), [=]FUSIBLE_DEVICE(int , int * SCANVAR, int const*, int, fusible_registers) {
+   m_conditionals.enqueue(RAJA::RangeSegment(0,1), [=]FUSIBLE_DEVICE(int , int * SCANVAR, int const*, int, XARGS...) {
       SCANVAR[end] = false;
    });
 
@@ -245,7 +245,7 @@ void LoopFuser<REGISTER_COUNT>::flush_parallel_scans(const char * fileName, int 
    care::host_device_ptr<int> scan_var(end+1, "scan_var");
    // this will fill scan_var up from the fused conditionals 
    m_cw = m_conditionals.instantiate();
-   m_cws = m_cw.run(scan_var.data(chai::GPU,true), nullptr, end+1, fusible_registers{});
+   m_cws = m_cw.run(scan_var.data(chai::GPU,true), nullptr, end+1, XARGS{}...);
 
    if (very_verbose) {
       CARE_SEQUENTIAL_LOOP(i, 0, end+1) {
@@ -285,7 +285,7 @@ void LoopFuser<REGISTER_COUNT>::flush_parallel_scans(const char * fileName, int 
    
    // execute the loop body
    m_aw = m_actions.instantiate();
-   m_aws = m_aw.run(scan_var.data(chai::GPU,true), fusible_registers{});
+   m_aws = m_aw.run(scan_var.data(chai::GPU,true), XARGS{}...);
 
    // need to do a synchronize data so pinned memory reads are valid
    care::gpuDeviceSynchronize(fileName,lineNumber);
@@ -312,8 +312,8 @@ void LoopFuser<REGISTER_COUNT>::flush_parallel_scans(const char * fileName, int 
 }
 
 
-template<int REGISTER_COUNT>
-void LoopFuser<REGISTER_COUNT>::flush_parallel_counts_to_offsets_scans(bool async, const char * fileName, int lineNumber) {
+template<int REGISTER_COUNT, typename...XARGS>
+void LoopFuser<REGISTER_COUNT,XARGS...>::flush_parallel_counts_to_offsets_scans(bool async, const char * fileName, int lineNumber) {
    if (verbose) {
      printf("in flush_counts_to_offsets_parallel_scans at %s:%i with %i,%i\n", fileName,lineNumber, m_action_count, m_max_action_length);
    }
@@ -324,7 +324,7 @@ void LoopFuser<REGISTER_COUNT>::flush_parallel_counts_to_offsets_scans(bool asyn
    care::host_device_ptr<int> scan_var(end, "scan_var");
    
    m_aw = m_actions.instantiate();
-   m_aws = m_aw.run(scan_var.data(chai::GPU, true), fusible_registers{});
+   m_aws = m_aw.run(scan_var.data(chai::GPU, true), XARGS{}...);
    
    if (very_verbose) {
       CARE_SEQUENTIAL_LOOP(i, 0, end) {
@@ -344,7 +344,7 @@ void LoopFuser<REGISTER_COUNT>::flush_parallel_counts_to_offsets_scans(bool asyn
    }
 
    m_cw = m_conditionals.instantiate();
-   m_cws = m_cw.run(scan_var.data(chai::GPU,true), offsets, end, fusible_registers{});
+   m_cws = m_cw.run(scan_var.data(chai::GPU,true), offsets, end, XARGS{}...);
 
 
    scan_var.free();
@@ -354,8 +354,8 @@ void LoopFuser<REGISTER_COUNT>::flush_parallel_counts_to_offsets_scans(bool asyn
    reset(async, fileName, lineNumber);
 }
 
-template<int REGISTER_COUNT>
-void LoopFuser<REGISTER_COUNT>::flushActions(bool async, const char * fileName, int lineNumber) {
+template<int REGISTER_COUNT, typename...XARGS>
+void LoopFuser<REGISTER_COUNT,XARGS...>::flushActions(bool async, const char * fileName, int lineNumber) {
    if (verbose) {
       printf("Loop fuser flushActions\n");
    }
@@ -393,9 +393,9 @@ void LoopFuser<REGISTER_COUNT>::flushActions(bool async, const char * fileName, 
    m_to_be_freed.clear();
 }
 
-template class LoopFuser<256>; 
-template class LoopFuser<128>; 
-template class LoopFuser<64>; 
-//template class LoopFuser<32>; 
+template class LoopFuser<32, FUSIBLE_REGISTERS(32)>; 
+template class LoopFuser<64, FUSIBLE_REGISTERS(64)>; 
+template class LoopFuser<128, FUSIBLE_REGISTERS(128)>; 
+template class LoopFuser<256, FUSIBLE_REGISTERS(256)>; 
 
 #endif

--- a/src/care/LoopFuser.h
+++ b/src/care/LoopFuser.h
@@ -1119,7 +1119,7 @@ void LoopFuser<REGISTER_COUNT>::registerFree(care::host_device_ptr<T> & array) {
 #define FUSIBLE_REGISTER_ARGS __FILE__, __LINE__, __fusible_start_index__, __fusible_end_index__
 
 // conditional xargs to pass in to lambdas
-#define FUSIBLE_CONDITIONAL_XARGS int * __fusible_scan_var__, index_type const * __fusible_scan_offsets__, fusible_registers
+#define FUSIBLE_CONDITIONAL_XARGS(REGISTER_COUNT) int * __fusible_scan_var__, index_type const * __fusible_scan_offsets__, LoopFuser<REGISTER_COUNT>::fusible_registers
 #define FUSIBLE_ALWAYS_TRUE(INDEX, REGISTER_COUNT) [=] FUSIBLE_DEVICE(index_type INDEX, int * __fusible_scan_var__, index_type const *, int, LoopFuser<REGISTER_COUNT>::fusible_registers) { FUSIBLE_INDEX_ADJUST(INDEX);  __fusible_scan_var__[__fusible_global_index__] = true; }
 // actions xargs to pass in to lambdas
 #define FUSIBLE_ACTION_XARGS(REGISTER_COUNT) index_type *, LoopFuser<REGISTER_COUNT>::fusible_registers 
@@ -1147,8 +1147,8 @@ void LoopFuser<REGISTER_COUNT>::registerFree(care::host_device_ptr<T> & array) {
    static int __fusible_scan_pos__ ; \
    __fusible_scan_pos__ = 0; \
    __fuser__->registerAction(__FILE__, __LINE__, 0, 1, __fusible_scan_pos__, \
-                             FUSIBLE_ALWAYS_TRUE(__i__), \
-                             [=] FUSIBLE_DEVICE(int, FUSIBLE_ACTION_XARGS)->int {
+                             FUSIBLE_ALWAYS_TRUE(__i__, REGISTER_COUNT), \
+                             [=] FUSIBLE_DEVICE(int, FUSIBLE_ACTION_XARGS(REGISTER_COUNT))->int {
 
 #define FUSIBLE_KERNEL FUSIBLE_KERNEL_R(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)
 
@@ -1185,7 +1185,7 @@ void LoopFuser<REGISTER_COUNT>::registerFree(care::host_device_ptr<T> & array) {
 #define FUSIBLE_KERNEL_R_END return 0;}); }
 
 #define FUSIBLE_KERNEL_PHASE(PRIORITY) FUSIBLE_KERNEL_PHASE_R(PRIORITY, CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)
-#define FUSIBLE_KERNEL_END FUSIBLE_KERNEL_END_R
+#define FUSIBLE_KERNEL_END FUSIBLE_KERNEL_R_END
 
 #define FUSIBLE_PHASE_RESET FusedActionsObserver::getActiveObserver()->reset_phases();
 

--- a/src/care/LoopFuser.h
+++ b/src/care/LoopFuser.h
@@ -783,7 +783,12 @@ class LoopFuser : public FusedActions {
       bool m_wait_needed = false;
 };
 
-
+// The FUSIBLE_REGISTERS_* macros define the type signature for the XARGS that LoopFuser will be templated on. They are designed
+// to provide function signatures that are unique to the each respective register bin. This ensures that the linker will only consider
+// fused loops within a register bin when doing block/grid/register size determinations. 
+// Note that for nvcc, the linker appears to consider LoopFuser<32> to be compatible with LoopFuser<64> etc, so differentiating the signature
+// by the integer template parameter was not sufficient. Thus we differentiate by number of parameters as well. 
+//
 #define FUSIBLE_REGISTERS_32 LoopFuser<32>::fusible_registers
 #define FUSIBLE_REGISTERS_64 LoopFuser<64>::fusible_registers, LoopFuser<64>::fusible_registers
 #define FUSIBLE_REGISTERS_128 LoopFuser<128>::fusible_registers, LoopFuser<128>::fusible_registers, LoopFuser<128>::fusible_registers

--- a/src/care/LoopFuser.h
+++ b/src/care/LoopFuser.h
@@ -969,16 +969,19 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 #else
 #define START_RECORDING(FUSER) FUSER->startRecording()
 #endif
+
+#define LOOPFUSER(REGISTER_COUNT) LoopFuser<REGISTER_COUNT, FUSIBLE_REGISTERS(REGISTER_COUNT)>
+
 #if defined(CARE_DEBUG) || defined(CARE_GPUCC) || CARE_ENABLE_GPU_SIMULATION_MODE
 
 // Start recording
 #define FUSIBLE_LOOPS_START { \
    static FusedActionsObserver * __phase_observer = new FusedActionsObserver(); \
    for ( FusedActions *__fuser__ : { \
-                                    static_cast<FusedActions *> (LoopFuser<256, FUSIBLE_REGISTERS(256)>::getInstance()),\
-                                    static_cast<FusedActions *> (LoopFuser<128, FUSIBLE_REGISTERS(128)>::getInstance()),\
-                                    static_cast<FusedActions *> (LoopFuser<64, FUSIBLE_REGISTERS(64)>::getInstance()),\
-                                    static_cast<FusedActions *> (LoopFuser<32, FUSIBLE_REGISTERS(32)>::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(256)::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(128)::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(64)::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(32)::getInstance()),\
                                     static_cast<FusedActions *>(__phase_observer)}) { \
       START_RECORDING(__fuser__); \
       __fuser__->preserveOrder(false); \
@@ -991,10 +994,10 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 #define FUSIBLE_LOOPS_PRESERVE_ORDER_START { \
    static FusedActionsObserver * __phase_observer = new FusedActionsObserver(); \
    for ( FusedActions *__fuser__ : {\
-                                    static_cast<FusedActions *> (LoopFuser<256, FUSIBLE_REGISTERS(256)>::getInstance()),\
-                                    static_cast<FusedActions *> (LoopFuser<128, FUSIBLE_REGISTERS(128)>::getInstance()),\
-                                    static_cast<FusedActions *> (LoopFuser<64, FUSIBLE_REGISTERS(64)>::getInstance()),\
-                                    static_cast<FusedActions *> (LoopFuser<32, FUSIBLE_REGISTERS(32)>::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(256)::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(128)::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(64)::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(32)::getInstance()),\
                                     static_cast<FusedActions *>(__phase_observer)}) { \
       START_RECORDING(__fuser__); \
       __fuser__->preserveOrder(true); \
@@ -1006,10 +1009,10 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 // Execute, then stop recording
 #define _FUSIBLE_LOOPS_STOP(ASYNC) { \
    for ( FusedActions *__fuser__ : {\
-                                    static_cast<FusedActions *> (LoopFuser<256, FUSIBLE_REGISTERS(256)>::getInstance()),\
-                                    static_cast<FusedActions *> (LoopFuser<128, FUSIBLE_REGISTERS(128)>::getInstance()),\
-                                    static_cast<FusedActions *> (LoopFuser<64, FUSIBLE_REGISTERS(64)>::getInstance()),\
-                                    static_cast<FusedActions *> (LoopFuser<32, FUSIBLE_REGISTERS(32)>::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(256)::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(128)::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(64)::getInstance()),\
+                                    static_cast<FusedActions *> (LOOPFUSER(32)::getInstance()),\
                                     static_cast<FusedActions *>(FusedActionsObserver::getActiveObserver())}) { \
       __fuser__->flushActions(ASYNC, __FILE__, __LINE__); \
       __fuser__->stopRecording(); \
@@ -1025,7 +1028,7 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 
 
 // frees
-#define FUSIBLE_FREE(A) LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance()->registerFree(A);
+#define FUSIBLE_FREE(A) LOOPFUSER(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)::getInstance()->registerFree(A);
 
 #else // defined(CARE_DEBUG) || defined(CARE_GPUCC) || CARE_ENABLE_GPU_SIMULATION_MODE
 
@@ -1034,10 +1037,10 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 { \
    static FusedActionsObserver * __phase_observer = new FusedActionsObserver(); \
    for ( FusedActions * __fuser__ : {\
-                                     static_cast<FusedActions *> (LoopFuser<256, FUSIBLE_REGISTERS(256)>::getInstance()),\
-                                     static_cast<FusedActions *> (LoopFuser<128, FUSIBLE_REGISTERS(128)>::getInstance()),\
-                                     static_cast<FusedActions *> (LoopFuser<64, FUSIBLE_REGISTERS(64)>::getInstance()),\
-                                     static_cast<FusedActions *> (LoopFuser<32, FUSIBLE_REGISTERS(32)>::getInstance()),\
+                                     static_cast<FusedActions *> (LOOPFUSER(256)::getInstance()),\
+                                     static_cast<FusedActions *> (LOOPFUSER(128)::getInstance()),\
+                                     static_cast<FusedActions *> (LOOPFUSER(64)::getInstance()),\
+                                     static_cast<FusedActions *> (LOOPFUSER(32)::getInstance()),\
                                      static_cast<FusedActions *>(__phase_observer)}) { \
       __fuser__->stopRecording(); \
       __fuser__->setScan(false); \
@@ -1141,7 +1144,7 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 #define FUSIBLE_ACTION_XARGS(REGISTER_COUNT) index_type *, FUSIBLE_REGISTERS(REGISTER_COUNT)
 
 #define FUSIBLE_LOOP_STREAM_R(INDEX, START, END, REGISTER_COUNT) { \
-   auto __fuser__ = LoopFuser<REGISTER_COUNT, FUSIBLE_REGISTERS(REGISTER_COUNT)>::getInstance(); \
+   auto __fuser__ = LOOPFUSER(REGISTER_COUNT)::getInstance(); \
    static int __fusible_scan_pos__ ; \
    __fusible_scan_pos__ = 0; \
    FUSIBLE_BOOKKEEPING(__fuser__,START,END, REGISTER_COUNT); \
@@ -1158,7 +1161,7 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 
 
 #define FUSIBLE_KERNEL_R(REGISTER_COUNT) { \
-   auto __fuser__ = LoopFuser<REGISTER_COUNT, FUSIBLE_REGISTERS(REGISTER_COUNT)>::getInstance(); \
+   auto __fuser__ = LOOPFUSER(REGISTER_COUNT)::getInstance(); \
    FUSIBLE_KERNEL_BOOKKEEPING(__fuser__) ; \
    static int __fusible_scan_pos__ ; \
    __fusible_scan_pos__ = 0; \
@@ -1170,7 +1173,7 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 
 #define FUSIBLE_LOOP_PHASE_R(INDEX, START, END, PRIORITY, REGISTER_COUNT) { \
    if (END > START) { \
-      LoopFuser<REGISTER_COUNT, FUSIBLE_REGISTERS(REGISTER_COUNT)> * __fuser__ = FusedActionsObserver::getActiveObserver()->getFusedActions<LoopFuser<REGISTER_COUNT, FUSIBLE_REGISTERS(REGISTER_COUNT)>>(PRIORITY); \
+      LOOPFUSER(REGISTER_COUNT) * __fuser__ = FusedActionsObserver::getActiveObserver()->getFusedActions<LOOPFUSER(REGISTER_COUNT)>(PRIORITY); \
       FUSIBLE_BOOKKEEPING(__fuser__, START, END, REGISTER_COUNT); \
       static int __fusible_scan_pos__; \
       __fusible_scan_pos__ = 0; \
@@ -1189,7 +1192,7 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 
 
 #define FUSIBLE_KERNEL_PHASE_R(PRIORITY, REGISTER_COUNT) { \
-   LoopFuser<REGISTER_COUNT, FUSIBLE_REGISTERS(REGISTER_COUNT)> * __fuser__ = FusedActionsObserver::getActiveObserver()->getFusedActions<LoopFuser<REGISTER_COUNT, FUSIBLE_REGISTERS(REGISTER_COUNT)>>(PRIORITY); \
+   LOOPFUSER(REGISTER_COUNT) * __fuser__ = FusedActionsObserver::getActiveObserver()->getFusedActions<LOOPFUSER(REGISTER_COUNT)>(PRIORITY); \
    static int __fusible_scan_pos__ ; \
    __fusible_scan_pos__ = 0; \
    __fuser__->registerAction(__FILE__, __LINE__, 0, 1, __fusible_scan_pos__, \
@@ -1206,16 +1209,15 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 #define FUSIBLE_PHASE_RESET FusedActionsObserver::getActiveObserver()->reset_phases();
 
 #define FUSIBLE_LOOPS_FENCEPOST { \
-   int __fusible_action_count__ = LoopFuser<256, FUSIBLE_REGISTERS(256)>::getInstance()->size(); \
-   __fusible_action_count__ += LoopFuser<128, FUSIBLE_REGISTERS(128)>::getInstance()->size(); \
-   __fusible_action_count__ += LoopFuser<64, FUSIBLE_REGISTERS(64)>::getInstance()->size(); \
-   __fusible_action_count__ += LoopFuser<32, FUSIBLE_REGISTERS(32)>::getInstance()->size(); \
+   int __fusible_action_count__ = LOOPFUSER(256)::getInstance()->size(); \
+   __fusible_action_count__ += LOOPFUSER(128)::getInstance()->size(); \
+   __fusible_action_count__ += LOOPFUSER(64)::getInstance()->size(); \
+   __fusible_action_count__ += LOOPFUSER(32)::getInstance()->size(); \
    if (__fusible_action_count__ > 0) { \
       std::cout << __FILE__ << "FUSIBLE_FENCEPOST reached before FUSIBLE_LOOPS_STOP occurred!" << std::endl; \
    } \
 }
 
-#define LOOPFUSER(REGISTER_COUNT) LoopFuser<REGISTER_COUNT, FUSIBLE_REGISTERS(REGISTER_COUNT)>
 // SCANS
 #define _FUSIBLE_LOOP_SCAN_R(FUSER, INDEX, START, END, POS, INIT_POS, BOOL_EXPR, REGISTER_COUNT) { \
    auto __fuser__ = FUSER; \
@@ -1257,7 +1259,7 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 // note - FUSED_SCANVAR will be nullptr if m_call_as_packed is set in registerAction, as there will be no need for an intermediate
 // FUSED_SCANVAR, so we won't need to write to it in the action or store into it in the conditional
 #define FUSIBLE_LOOP_COUNTS_TO_OFFSETS_SCAN_R(INDEX,START,END,SCANVAR, REGISTER_COUNT)  { \
-   auto __fuser__ = LoopFuser<REGISTER_COUNT, FUSIBLE_REGISTERS(REGISTER_COUNT)>::getInstance(); \
+   auto __fuser__ = LOOPFUSER(REGISTER_COUNT)::getInstance(); \
    FUSIBLE_BOOKKEEPING(__fuser__, START, END, REGISTER_COUNT); \
    static int __fusible_scan_pos__; \
    __fusible_scan_pos__ = 0; \

--- a/src/care/LoopFuser.h
+++ b/src/care/LoopFuser.h
@@ -1207,9 +1207,9 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 
 #define FUSIBLE_LOOPS_FENCEPOST { \
    int __fusible_action_count__ = LoopFuser<256, FUSIBLE_REGISTERS(256)>::getInstance()->size(); \
-   int __fusible_action_count__ = LoopFuser<128, FUSIBLE_REGISTERS(128)>::getInstance()->size(); \
-   int __fusible_action_count__ = LoopFuser<64, FUSIBLE_REGISTERS(64)>::getInstance()->size(); \
-   int __fusible_action_count__ = LoopFuser<32, FUSIBLE_REGISTERS(32)>::getInstance()->size(); \
+   __fusible_action_count__ += LoopFuser<128, FUSIBLE_REGISTERS(128)>::getInstance()->size(); \
+   __fusible_action_count__ += LoopFuser<64, FUSIBLE_REGISTERS(64)>::getInstance()->size(); \
+   __fusible_action_count__ += LoopFuser<32, FUSIBLE_REGISTERS(32)>::getInstance()->size(); \
    if (__fusible_action_count__ > 0) { \
       std::cout << __FILE__ << "FUSIBLE_FENCEPOST reached before FUSIBLE_LOOPS_STOP occurred!" << std::endl; \
    } \
@@ -1244,7 +1244,7 @@ void LoopFuser<REGISTER_COUNT, XARGS...>::registerFree(care::host_device_ptr<T> 
 #define FUSIBLE_LOOP_SCAN_END(LENGTH, POS, POS_STORE_DESTINATION) FUSIBLE_LOOP_SCAN_R_END(LENGTH, POS, POS_STORE_DESTINATION)
 
 #define FUSIBLE_LOOP_SCAN_PHASE_R(INDEX, START, END, POS, INIT_POS, BOOL_EXPR, PRIORITY, REGISTER_COUNT) \
-   _FUSIBLE_LOOP_SCAN_R(FusedActionsObserver::getActiveObserver()->getFusedActions<LoopFuser<REGISTER_COUNT, FUSIBLE_REGISTERS(REGISTER_COUNT)>>(PRIORITY), \
+   _FUSIBLE_LOOP_SCAN_R(FusedActionsObserver::getActiveObserver()->getFusedActions<LOOPFUSER(REGISTER_COUNT)>(PRIORITY), \
                         INDEX, START, END, POS, INIT_POS, BOOL_EXPR, REGISTER_COUNT)
 
 #define FUSIBLE_LOOP_SCAN_PHASE(INDEX, START, END, POS, INIT_POS, BOOL_EXPR, PRIORITY) \

--- a/test/Benchmarks.cpp
+++ b/test/Benchmarks.cpp
@@ -63,7 +63,7 @@ CUDA_TEST(TestFuser, Initialization) {
    trigger_device_allocation.free();
    trigger_pinned_allocation.free();
    // initialize loop fuser
-   LoopFuser::getInstance();
+   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT>::getInstance();
 
    care::syncIfNeeded();
    printf("Initialized... Benchmarking Loop Fusion\n");
@@ -94,7 +94,7 @@ CUDA_TEST(TestFuser, OneMillionSmallFusedKernels) {
    int loopLength = 32;
    int_ptr a(loopLength,"a");
    int_ptr b(loopLength,"b");
-   LoopFuser::getInstance()->setVerbose(true);
+   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT>::getInstance()->setVerbose(true);
    
    FUSIBLE_LOOPS_START 
    for (int i = 0; i < numLoops; ++i) {

--- a/test/Benchmarks.cpp
+++ b/test/Benchmarks.cpp
@@ -63,7 +63,7 @@ CUDA_TEST(TestFuser, Initialization) {
    trigger_device_allocation.free();
    trigger_pinned_allocation.free();
    // initialize loop fuser
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT>::getInstance();
+   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance();
 
    care::syncIfNeeded();
    printf("Initialized... Benchmarking Loop Fusion\n");
@@ -94,7 +94,7 @@ CUDA_TEST(TestFuser, OneMillionSmallFusedKernels) {
    int loopLength = 32;
    int_ptr a(loopLength,"a");
    int_ptr b(loopLength,"b");
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT>::getInstance()->setVerbose(true);
+   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance()->setVerbose(true);
    
    FUSIBLE_LOOPS_START 
    for (int i = 0; i < numLoops; ++i) {

--- a/test/Benchmarks.cpp
+++ b/test/Benchmarks.cpp
@@ -63,7 +63,7 @@ CUDA_TEST(TestFuser, Initialization) {
    trigger_device_allocation.free();
    trigger_pinned_allocation.free();
    // initialize loop fuser
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance();
+   LOOPFUSER(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)::getInstance();
 
    care::syncIfNeeded();
    printf("Initialized... Benchmarking Loop Fusion\n");
@@ -94,7 +94,7 @@ CUDA_TEST(TestFuser, OneMillionSmallFusedKernels) {
    int loopLength = 32;
    int_ptr a(loopLength,"a");
    int_ptr b(loopLength,"b");
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance()->setVerbose(true);
+   LOOPFUSER(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)::getInstance()->setVerbose(true);
    
    FUSIBLE_LOOPS_START 
    for (int i = 0; i < numLoops; ++i) {

--- a/test/LoopFuserTest.cxx
+++ b/test/LoopFuserTest.cxx
@@ -73,8 +73,8 @@ GPU_TEST(TestPacker, packFixedRange) {
 
    int pos = 0;
    packer->registerAction(__FILE__, __LINE__, 0, arrSize, pos,
-                          [=] CARE_DEVICE(int, int *, int const*, int, LoopFuser<64>::fusible_registers) { },
-                          [=] CARE_DEVICE(int i, int *, LoopFuser<64>::fusible_registers) {
+                          [=] CARE_DEVICE(int, int *, int const*, int, FUSIBLE_REGISTERS(64)) { },
+                          [=] CARE_DEVICE(int i, int *, FUSIBLE_REGISTERS(64)) {
       dst[pos+i] = src[i];
    });
 
@@ -131,8 +131,8 @@ GPU_TEST(TestPacker, packFixedRangeMacro) {
       auto __fusible_offset__ = __fuser__->getOffset();
       int scan_pos = 0;
       __fuser__->registerAction(__FILE__, __LINE__, 0, arrSize, scan_pos,
-                                [=] FUSIBLE_DEVICE(int, int *, int const*, int, LoopFuser<64>::fusible_registers){ },
-                                [=] FUSIBLE_DEVICE(int i, int *, LoopFuser<64>::fusible_registers) {
+                                [=] FUSIBLE_DEVICE(int, int *, int const*, int, FUSIBLE_REGISTERS(64)){ },
+                                [=] FUSIBLE_DEVICE(int i, int *, FUSIBLE_REGISTERS(64)) {
          i += 0 -  __fusible_offset__ ;
          if (i < arrSize) {
             dst[pos+i] = src[i];
@@ -354,7 +354,7 @@ GPU_TEST(fusible_scan, basic_fusible_scan) {
    } FUSIBLE_LOOP_SCAN_END(arrSize, pos, ab_pos)
 
    FUSIBLE_LOOPS_STOP
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT>::getInstance()->setVerbose(false);
+   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance()->setVerbose(false);
 
    // sum up the results of the scans
    RAJAReduceSum<int> sumA(0);

--- a/test/LoopFuserTest.cxx
+++ b/test/LoopFuserTest.cxx
@@ -58,7 +58,7 @@ TEST(UpperBound_binarySearch, checkOffsets) {
 }
 
 GPU_TEST(TestPacker, packFixedRange) {
-   LoopFuser<64, FUSIBLE_REGISTERS(64)> * packer = LoopFuser<64, FUSIBLE_REGISTERS(64)>::getInstance();
+   LOOPFUSER(64) * packer = LOOPFUSER(64)::getInstance();
    packer->startRecording();
   
    int arrSize = 1024;
@@ -127,7 +127,7 @@ GPU_TEST(TestPacker, packFixedRangeMacro) {
    int pos = 0;
 
    {
-      auto __fuser__ = LoopFuser<64, FUSIBLE_REGISTERS(64)>::getInstance();
+      auto __fuser__ = LOOPFUSER(64)::getInstance();
       auto __fusible_offset__ = __fuser__->getOffset();
       int scan_pos = 0;
       __fuser__->registerAction(__FILE__, __LINE__, 0, arrSize, scan_pos,
@@ -336,7 +336,7 @@ GPU_TEST(fusible_scan, basic_fusible_scan) {
    } CARE_STREAM_LOOP_END
 
    FUSIBLE_LOOPS_START
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance()->setVerbose(true);
+   LOOPFUSER(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)::getInstance()->setVerbose(true);
 
    int a_pos = 0;
    int b_pos = 0;
@@ -354,7 +354,7 @@ GPU_TEST(fusible_scan, basic_fusible_scan) {
    } FUSIBLE_LOOP_SCAN_END(arrSize, pos, ab_pos)
 
    FUSIBLE_LOOPS_STOP
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance()->setVerbose(false);
+   LOOPFUSER(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)::getInstance()->setVerbose(false);
 
    // sum up the results of the scans
    RAJAReduceSum<int> sumA(0);
@@ -579,7 +579,7 @@ GPU_TEST(fusible_scan_custom, basic_fusible_scan_custom) {
    } CARE_STREAM_LOOP_END
 
    FUSIBLE_LOOPS_START
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance()->setVerbose(true);
+   LOOPFUSER(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)::getInstance()->setVerbose(true);
 
    FUSIBLE_LOOP_COUNTS_TO_OFFSETS_SCAN(i, 0, arrSize, A) {
       A[i] = 2;
@@ -590,7 +590,7 @@ GPU_TEST(fusible_scan_custom, basic_fusible_scan_custom) {
    } FUSIBLE_LOOP_COUNTS_TO_OFFSETS_SCAN_END(i, arrSize, B)
 
    FUSIBLE_LOOPS_STOP
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance()->setVerbose(false);
+   LOOPFUSER(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)::getInstance()->setVerbose(false);
 
    //  check answer
    CARE_SEQUENTIAL_LOOP(i, 0, arrSize*2) {

--- a/test/LoopFuserTest.cxx
+++ b/test/LoopFuserTest.cxx
@@ -58,7 +58,7 @@ TEST(UpperBound_binarySearch, checkOffsets) {
 }
 
 GPU_TEST(TestPacker, packFixedRange) {
-   LoopFuser<64> * packer = LoopFuser<64>::getInstance();
+   LoopFuser<64, FUSIBLE_REGISTERS(64)> * packer = LoopFuser<64, FUSIBLE_REGISTERS(64)>::getInstance();
    packer->startRecording();
   
    int arrSize = 1024;
@@ -127,7 +127,7 @@ GPU_TEST(TestPacker, packFixedRangeMacro) {
    int pos = 0;
 
    {
-      auto __fuser__ = LoopFuser<64>::getInstance();
+      auto __fuser__ = LoopFuser<64, FUSIBLE_REGISTERS(64)>::getInstance();
       auto __fusible_offset__ = __fuser__->getOffset();
       int scan_pos = 0;
       __fuser__->registerAction(__FILE__, __LINE__, 0, arrSize, scan_pos,
@@ -336,7 +336,7 @@ GPU_TEST(fusible_scan, basic_fusible_scan) {
    } CARE_STREAM_LOOP_END
 
    FUSIBLE_LOOPS_START
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT>::getInstance()->setVerbose(true);
+   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance()->setVerbose(true);
 
    int a_pos = 0;
    int b_pos = 0;
@@ -579,7 +579,7 @@ GPU_TEST(fusible_scan_custom, basic_fusible_scan_custom) {
    } CARE_STREAM_LOOP_END
 
    FUSIBLE_LOOPS_START
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT>::getInstance()->setVerbose(true);
+   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance()->setVerbose(true);
 
    FUSIBLE_LOOP_COUNTS_TO_OFFSETS_SCAN(i, 0, arrSize, A) {
       A[i] = 2;
@@ -590,7 +590,7 @@ GPU_TEST(fusible_scan_custom, basic_fusible_scan_custom) {
    } FUSIBLE_LOOP_COUNTS_TO_OFFSETS_SCAN_END(i, arrSize, B)
 
    FUSIBLE_LOOPS_STOP
-   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT>::getInstance()->setVerbose(false);
+   LoopFuser<CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT, FUSIBLE_REGISTERS(CARE_DEFAULT_LOOP_FUSER_REGISTER_COUNT)>::getInstance()->setVerbose(false);
 
    //  check answer
    CARE_SEQUENTIAL_LOOP(i, 0, arrSize*2) {


### PR DESCRIPTION
SUMMARY:
LoopFuser is now templated on max register count and a bin-specific function signature

Details:
all preexisting FUSIBLE_LOOP_* macros use default value of 256.
Can use new FUSIBLE_LOOP_*_R(REGISTER_COUNT) macros to select 32, 64,128, or 256 max register counts.
If different count values are used within the same FUSIBLE_LOOPS_START / FUSIBLE_LOOPS_STOP region, one kernel launch will occur for each value.

Attempts to use values other than 32, 64,128, or 256 will result in compiler errors.
Exceeding the max register count in a fused kernel will result in a linking error.
Using lower max count will result in better occupancy, improving performance for fused kernels with large numbers of threads by up to 8x.