### PR TITLE
Fix Loop Fuser Variant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@
 cmake_minimum_required(VERSION 3.4)
 
 project(care LANGUAGES CXX)
+include(CMakeDependentOption)
 
 ################################
 # Build options
@@ -33,7 +34,7 @@ option(CARE_ENABLE_MANAGED_PTR "Enable managed_ptr aliases, tests, and reproduce
 option(CARE_DISABLE_RAJAPLUGIN "Disable use of the RAJA plugin. WILL ALSO DISABLE MEMORY MOTION." OFF)
 option(CARE_ENABLE_EXTERN_INSTANTIATE "Enable extern instantiation of template functions" OFF)
 option(CARE_ENABLE_GPU_SIMULATION_MODE "Enable GPU simulation mode." OFF )
-option(CARE_ENABLE_LOOP_FUSER "Enable the loop fuser" OFF)
+cmake_dependent_option(CARE_ENABLE_LOOP_FUSER "Enable the loop fuser" OFF "ENABLE_CUDA OR ENABLE_HIP" OFF)
 
 #  Known to not compile for Debug configurations, have low probability of working in 
 #  practice for Release / RelWithDebInfo configurations.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ option(CARE_ENABLE_MANAGED_PTR "Enable managed_ptr aliases, tests, and reproduce
 option(CARE_DISABLE_RAJAPLUGIN "Disable use of the RAJA plugin. WILL ALSO DISABLE MEMORY MOTION." OFF)
 option(CARE_ENABLE_EXTERN_INSTANTIATE "Enable extern instantiation of template functions" OFF)
 option(CARE_ENABLE_GPU_SIMULATION_MODE "Enable GPU simulation mode." OFF )
+option(CARE_ENABLE_LOOP_FUSER "Enable the loop fuser" OFF)
+
 #  Known to not compile for Debug configurations, have low probability of working in 
 #  practice for Release / RelWithDebInfo configurations.
 option(CARE_ENABLE_FUSER_BIN_32 "Enable the 32 register fusible loop bin." OFF)
@@ -116,11 +118,8 @@ if (ENABLE_CUDA)
 
    # CUDA optional dependencies without submodules (not open source)
    set(NVTOOLSEXT_DIR "" CACHE PATH "Path to external NVTOOLSEXT")
-   # Optional features
-   set(CARE_ENABLE_LOOP_FUSER ON CACHE STRING "Enable the loop fuser")
-else()
-   set(CARE_ENABLE_LOOP_FUSER OFF CACHE STRING "Enable the loop fuser")
 endif()
+
 ################################
 # BLT
 ################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@
 cmake_minimum_required(VERSION 3.4)
 
 project(care LANGUAGES CXX)
-include(CMakeDependentOption)
 
 ################################
 # Build options
@@ -34,7 +33,7 @@ option(CARE_ENABLE_MANAGED_PTR "Enable managed_ptr aliases, tests, and reproduce
 option(CARE_DISABLE_RAJAPLUGIN "Disable use of the RAJA plugin. WILL ALSO DISABLE MEMORY MOTION." OFF)
 option(CARE_ENABLE_EXTERN_INSTANTIATE "Enable extern instantiation of template functions" OFF)
 option(CARE_ENABLE_GPU_SIMULATION_MODE "Enable GPU simulation mode." OFF )
-cmake_dependent_option(CARE_ENABLE_LOOP_FUSER "Enable the loop fuser" OFF "ENABLE_CUDA OR ENABLE_HIP" OFF)
+option(CARE_ENABLE_LOOP_FUSER "Enable the loop fuser" ON)
 
 #  Known to not compile for Debug configurations, have low probability of working in 
 #  practice for Release / RelWithDebInfo configurations.

--- a/src/care/CMakeLists.txt
+++ b/src/care/CMakeLists.txt
@@ -38,7 +38,6 @@ set(care_headers
     KeyValueSorter_inst.h
     local_host_device_ptr.h
     local_ptr.h
-    LoopFuser.h
     managed_ptr.h
     openmp.h
     SortFuser.h
@@ -57,10 +56,14 @@ set(care_headers
 set(care_sources
     care.cpp
     CHAICallback.cpp
-    LoopFuser.cpp
     RAJAPlugin.cpp
     scan.cpp
     )
+
+if (CARE_ENABLE_LOOP_FUSER)
+   list(APPEND care_headers LoopFuser.h)
+   list(APPEND care_sources LoopFuser.cpp)
+endif()
 
 if(CARE_ENABLE_EXTERN_INSTANTIATE)
    list(APPEND care_headers care_inst.h)

--- a/test/Benchmarks.cpp
+++ b/test/Benchmarks.cpp
@@ -53,6 +53,8 @@ static unsigned int currentColor = 0;
 using namespace care;
 using int_ptr = host_device_ptr<int>;
 
+#if defined(CARE_GPUCC)
+//This test is not valid on the CPU since AllocationStrategy chai::PINNED does not exist for that build.
 CUDA_TEST(TestFuser, Initialization) {
    printf("Initializing\n");
    // initializing and allocate memory pools
@@ -68,7 +70,7 @@ CUDA_TEST(TestFuser, Initialization) {
    care::syncIfNeeded();
    printf("Initialized... Benchmarking Loop Fusion\n");
 }
-
+#endif //CARE_GPUCC
 
 CUDA_TEST(TestFuser, OneMillionSmallKernels) {
    int numLoops = 1000000;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -153,15 +153,18 @@ target_include_directories(TestScan
 blt_add_test( NAME TestScan
               COMMAND TestScan )
 
-blt_add_executable( NAME Benchmarks
-                    SOURCES Benchmarks.cpp
-                    DEPENDS_ON ${care_test_dependencies} )
+if (CARE_ENABLE_LOOP_FUSER)
+   blt_add_executable( NAME Benchmarks
+                       SOURCES Benchmarks.cpp
+                       DEPENDS_ON ${care_test_dependencies} )
 
-target_include_directories(Benchmarks
-                           PRIVATE ${PROJECT_SOURCE_DIR}/src)
+   target_include_directories(Benchmarks
+                              PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
-target_include_directories(Benchmarks
-                           PRIVATE ${PROJECT_BINARY_DIR}/include)
+   target_include_directories(Benchmarks
+                              PRIVATE ${PROJECT_BINARY_DIR}/include)
 
-blt_add_test( NAME Benchmarks
-              COMMAND Benchmarks )
+   blt_add_test( NAME Benchmarks
+                 COMMAND Benchmarks )
+endif()
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,19 @@ if (CARE_ENABLE_LOOP_FUSER)
 
    blt_add_test( NAME TestSortFuser
                  COMMAND TestSortFuser )
+
+   blt_add_executable( NAME Benchmarks
+                       SOURCES Benchmarks.cpp
+                       DEPENDS_ON ${care_test_dependencies} )
+
+   target_include_directories(Benchmarks
+                              PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
+   target_include_directories(Benchmarks
+                              PRIVATE ${PROJECT_BINARY_DIR}/include)
+
+   blt_add_test( NAME Benchmarks
+                 COMMAND Benchmarks )
 endif()
 
 blt_add_executable( NAME TestArray

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,31 +32,33 @@ target_include_directories(TestForall
 blt_add_test( NAME TestForall
               COMMAND TestForall )
 
-blt_add_executable( NAME TestLoopFuser
-                    SOURCES LoopFuserTest.cxx
-                    DEPENDS_ON ${care_test_dependencies} )
+if (CARE_ENABLE_LOOP_FUSER)
+   blt_add_executable( NAME TestLoopFuser
+                       SOURCES LoopFuserTest.cxx
+                       DEPENDS_ON ${care_test_dependencies} )
 
-target_include_directories(TestLoopFuser
-                           PRIVATE ${PROJECT_SOURCE_DIR}/src)
+   target_include_directories(TestLoopFuser
+                              PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
-target_include_directories(TestLoopFuser
-                           PRIVATE ${PROJECT_BINARY_DIR}/include)
+   target_include_directories(TestLoopFuser
+                              PRIVATE ${PROJECT_BINARY_DIR}/include)
 
-blt_add_test( NAME TestLoopFuser
-              COMMAND TestLoopFuser )
+   blt_add_test( NAME TestLoopFuser
+                 COMMAND TestLoopFuser )
 
-blt_add_executable( NAME TestSortFuser
-                    SOURCES TestSortFuser.cxx
-                    DEPENDS_ON ${care_test_dependencies} )
+   blt_add_executable( NAME TestSortFuser
+                       SOURCES TestSortFuser.cxx
+                       DEPENDS_ON ${care_test_dependencies} )
 
-target_include_directories(TestSortFuser
-                           PRIVATE ${PROJECT_SOURCE_DIR}/src)
+   target_include_directories(TestSortFuser
+                              PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
-target_include_directories(TestSortFuser
-                           PRIVATE ${PROJECT_BINARY_DIR}/include)
+   target_include_directories(TestSortFuser
+                              PRIVATE ${PROJECT_BINARY_DIR}/include)
 
-blt_add_test( NAME TestSortFuser
-              COMMAND TestSortFuser )
+   blt_add_test( NAME TestSortFuser
+                 COMMAND TestSortFuser )
+endif()
 
 blt_add_executable( NAME TestArray
                     SOURCES TestArray.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -125,19 +125,6 @@ if (CARE_ENABLE_MANAGED_PTR)
 
    blt_add_test( NAME TestManagedPtr
                  COMMAND TestManagedPtr )
-
-   blt_add_executable( NAME Benchmarks
-                       SOURCES Benchmarks.cpp
-                       DEPENDS_ON ${care_test_dependencies} )
-
-   target_include_directories(Benchmarks
-                              PRIVATE ${PROJECT_SOURCE_DIR}/src)
-
-   target_include_directories(Benchmarks
-                              PRIVATE ${PROJECT_BINARY_DIR}/include)
-
-   blt_add_test( NAME Benchmarks
-                 COMMAND Benchmarks )
 endif()
 
 blt_add_executable( NAME TestNumeric

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -112,6 +112,19 @@ if (CARE_ENABLE_MANAGED_PTR)
 
    blt_add_test( NAME TestManagedPtr
                  COMMAND TestManagedPtr )
+
+   blt_add_executable( NAME Benchmarks
+                       SOURCES Benchmarks.cpp
+                       DEPENDS_ON ${care_test_dependencies} )
+
+   target_include_directories(Benchmarks
+                              PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
+   target_include_directories(Benchmarks
+                              PRIVATE ${PROJECT_BINARY_DIR}/include)
+
+   blt_add_test( NAME Benchmarks
+                 COMMAND Benchmarks )
 endif()
 
 blt_add_executable( NAME TestNumeric
@@ -152,19 +165,4 @@ target_include_directories(TestScan
 
 blt_add_test( NAME TestScan
               COMMAND TestScan )
-
-if (CARE_ENABLE_LOOP_FUSER)
-   blt_add_executable( NAME Benchmarks
-                       SOURCES Benchmarks.cpp
-                       DEPENDS_ON ${care_test_dependencies} )
-
-   target_include_directories(Benchmarks
-                              PRIVATE ${PROJECT_SOURCE_DIR}/src)
-
-   target_include_directories(Benchmarks
-                              PRIVATE ${PROJECT_BINARY_DIR}/include)
-
-   blt_add_test( NAME Benchmarks
-                 COMMAND Benchmarks )
-endif()
 

--- a/test/LoopFuserTest.cxx
+++ b/test/LoopFuserTest.cxx
@@ -318,6 +318,10 @@ FUSIBLE_DEVICE bool printAndAssign(care::host_device_ptr<int> B, int i) {
    return B[i] == 1;
 }
 
+#if defined(CARE_GPUCC)
+// parallel scans cannot work on CPU-only builds. This will call  void LoopFuser<REGISTER_COUNT,XARGS...>::flush_parallel_scans,
+// which fails at the line m_cws = m_cw.run(scan_var.data(chai::GPU,true), nullptr, end+1, XARGS{}...);. Specifying chai::GPU
+// is not correct for CPU-only builds
 GPU_TEST(fusible_scan, basic_fusible_scan) {
    // arrSize should be even for this test
    int arrSize = 4;
@@ -375,7 +379,12 @@ GPU_TEST(fusible_scan, basic_fusible_scan) {
    EXPECT_EQ(b_pos, arrSize/2);
    EXPECT_EQ(ab_pos, arrSize);
 }
+#endif // CARE_GPUCC
 
+#if defined(CARE_GPUCC)
+// parallel scans cannot work on CPU-only builds. This will call  void LoopFuser<REGISTER_COUNT,XARGS...>::flush_parallel_scans,
+// which fails at the line m_cws = m_cw.run(scan_var.data(chai::GPU,true), nullptr, end+1, XARGS{}...);. Specifying chai::GPU
+// is not correct for CPU-only builds
 GPU_TEST(fusible_dependent_scan, basic_dependent_fusible_scan) {
    // sarrSize should be even for this test
    int arrSize = 4;
@@ -451,7 +460,12 @@ GPU_TEST(fusible_dependent_scan, basic_dependent_fusible_scan) {
    // check scan positions
    EXPECT_EQ(result_pos, arrSize*2);
 }
+#endif // CARE_GPUCC
 
+#if defined(CARE_GPUCC)
+// parallel scans cannot work on CPU-only builds. This will call  void LoopFuser<REGISTER_COUNT,XARGS...>::flush_parallel_scans,
+// which fails at the line m_cws = m_cw.run(scan_var.data(chai::GPU,true), nullptr, end+1, XARGS{}...);. Specifying chai::GPU
+// is not correct for CPU-only builds
 GPU_TEST(fusible_loops_and_scans, mix_and_match) {
    // should be even for this test
    int arrSize = 4;
@@ -555,7 +569,12 @@ GPU_TEST(fusible_loops_and_scans, mix_and_match) {
       EXPECT_EQ(E[i], 3*i);
    } CARE_SEQUENTIAL_LOOP_END
 }
+#endif // CARE_GPUCC
 
+#if defined(CARE_GPUCC)
+// parallel custom scans cannot work on CPU-only builds. This will call LoopFuser<REGISTER_COUNT,XARGS...>::flush_parallel_counts_to_offsets_scans,
+// which fails at the line m_aws = m_aw.run(scan_var.data(chai::GPU, true), XARGS{}...);. Specifying chai::GPU
+// is not correct for CPU-only builds
 GPU_TEST(fusible_scan_custom, basic_fusible_scan_custom) {
    // arrSize should be even for this test
    int arrSize = 4;
@@ -604,7 +623,11 @@ GPU_TEST(fusible_scan_custom, basic_fusible_scan_custom) {
    } CARE_SEQUENTIAL_LOOP_END
 
 }
+#endif // CARE_GPUCC
 
+#if defined(CARE_GPUCC)
+// This test explicitly calls registerTouch(care::GPU);, which leads to m_pointer_record->m_pointers[GPU] in chai. 
+// This means that it cannot be run on CPU-only builds. TODO: generalize this test so we can try it on the CPU.
 GPU_TEST(fusible_phase, fusible_loop_phase) {
    int arrSize = 128;
    int timesteps = 3;
@@ -718,6 +741,8 @@ GPU_TEST(fusible_phase, fusible_loop_phase) {
    }
 
 }
+#endif // CARE_GPUCC
+
 // TODO: FUSIBLE_LOOP_STREAM Should not batch if FUSIBLE_LOOPS_START has not been called.
 // TODO: test with two START and STOP to make sure new stuff is overwriting the old stuff.
 //


### PR DESCRIPTION
Before this PR Loop fuser files and tests were built even if CARE_ENABLE_LOOP_FUSER is set to OFF. This fixes that build issue. 

With this PR, if CARE_ENABLE_LOOP_FUSER is set ON, then loop fuser functionality is exercised (whether set on CPU or GPU builds). If it is OFF, then loop fuser files and tests are not compiled

Attempting to exercise loop fuser functionality on the CPU builds results in some errors, so I ifdefed those tests out. That is an issue for a future PR


