### PR TITLE
Allow care_inst.h to be included with or without external instantiations

### DIFF
--- a/src/care/CMakeLists.txt
+++ b/src/care/CMakeLists.txt
@@ -22,6 +22,7 @@ set(care_headers
     algorithm_impl.h
     array.h
     atomic.h
+    care_inst.h
     CHAICallback.h
     CHAIDataGetter.h
     GPUWatchpoint.h
@@ -65,7 +66,6 @@ set(care_sources
     )
 
 if(CARE_ENABLE_EXTERN_INSTANTIATE)
-   list(APPEND care_headers care_inst.h)
    list(APPEND care_sources care_inst.cpp)
 endif()
 

--- a/src/care/care_inst.h
+++ b/src/care/care_inst.h
@@ -4,9 +4,7 @@
 // CARE config header
 #include "care/config.h"
 
-#ifndef CARE_ENABLE_EXTERN_INSTANTIATE
-#error "CARE external instantiations may only be used with CARE_ENABLE_EXTERN_INSTANTIATE"
-#endif
+#ifdef CARE_ENABLE_EXTERN_INSTANTIATE
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -1211,5 +1209,12 @@ int PickAndPerformFindMaxIndex<double, RAJA::seq_exec>(care::host_device_ptr<con
 ///////////////////////////////////////////////////////////////////////////////
 
 } // namespace care
+
+#else // CARE_ENABLE_EXTERN_INSTANTIATE
+
+// Just include the header if we are not using external instantiations
+#include "care/KeyValueSorter.h"
+
+#endif // else CARE_ENABLE_EXTERN_INSTANTIATE
 
 #endif // __CARE_INST_H


### PR DESCRIPTION
Allow care_inst.h to be included with or without explicit instantiations enabled
- If explicit instantiations are disabled, will include inline implementations