### PR TITLE
Add GIDTYPE instances

### DIFF
--- a/src/care/care_inst.h
+++ b/src/care/care_inst.h
@@ -38,13 +38,17 @@
 #include "care/KeyValueSorter_inst.h"
 
 #if CARE_HAVE_LLNL_GLOBALID
+
 #define CARE_TEMPLATE_KEY_TYPE int
 #define CARE_TEMPLATE_ARRAY_TYPE globalID
 #include "care/KeyValueSorter_inst.h"
 
+#if GLOBALID_IS_64BIT
 #define CARE_TEMPLATE_KEY_TYPE GIDTYPE
 #define CARE_TEMPLATE_ARRAY_TYPE int
 #include "care/KeyValueSorter_inst.h"
+#endif
+
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/care/care_inst.h
+++ b/src/care/care_inst.h
@@ -159,10 +159,14 @@ CARE_HOST_DEVICE int BinarySearch(const int *, const int, const int, const int, 
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const size_t *, const int, const int, const size_t, bool) ;
 #if CARE_HAVE_LLNL_GLOBALID
+
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const globalID *, const int, const int, const globalID, bool) ;
+#if GLOBALID_IS_64BIT
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const GIDTYPE *, const int, const int, const GIDTYPE, bool) ;
+#endif
+
 #endif
 
 CARE_EXTERN template CARE_DLL_API
@@ -170,10 +174,14 @@ CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<int>&, const int, 
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<size_t>&, const int, const int, const size_t, bool) ;
 #if CARE_HAVE_LLNL_GLOBALID
+
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<globalID>&, const int, const int, const globalID, bool) ;
+#if GLOBALID_IS_64BIT
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<GIDTYPE>&, const int, const int, const GIDTYPE, bool) ;
+#endif
+
 #endif
 
 CARE_EXTERN template CARE_DLL_API
@@ -181,10 +189,14 @@ CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<const int>&, const
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<const size_t>&, const int, const int, const size_t, bool) ;
 #if CARE_HAVE_LLNL_GLOBALID
+
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<const globalID>&, const int, const int, const globalID, bool) ;
+#if GLOBALID_IS_64BIT
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<const GIDTYPE>&, const int, const int, const GIDTYPE, bool) ;
+#endif
+
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/care/care_inst.h
+++ b/src/care/care_inst.h
@@ -41,6 +41,10 @@
 #define CARE_TEMPLATE_KEY_TYPE int
 #define CARE_TEMPLATE_ARRAY_TYPE globalID
 #include "care/KeyValueSorter_inst.h"
+
+#define CARE_TEMPLATE_KEY_TYPE GIDTYPE
+#define CARE_TEMPLATE_ARRAY_TYPE int
+#include "care/KeyValueSorter_inst.h"
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -153,6 +157,8 @@ CARE_HOST_DEVICE int BinarySearch(const size_t *, const int, const int, const si
 #if CARE_HAVE_LLNL_GLOBALID
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const globalID *, const int, const int, const globalID, bool) ;
+CARE_EXTERN template CARE_DLL_API
+CARE_HOST_DEVICE int BinarySearch(const GIDTYPE *, const int, const int, const GIDTYPE, bool) ;
 #endif
 
 CARE_EXTERN template CARE_DLL_API
@@ -162,6 +168,8 @@ CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<size_t>&, const in
 #if CARE_HAVE_LLNL_GLOBALID
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<globalID>&, const int, const int, const globalID, bool) ;
+CARE_EXTERN template CARE_DLL_API
+CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<GIDTYPE>&, const int, const int, const GIDTYPE, bool) ;
 #endif
 
 CARE_EXTERN template CARE_DLL_API
@@ -171,6 +179,8 @@ CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<const size_t>&, co
 #if CARE_HAVE_LLNL_GLOBALID
 CARE_EXTERN template CARE_DLL_API
 CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<const globalID>&, const int, const int, const globalID, bool) ;
+CARE_EXTERN template CARE_DLL_API
+CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<const GIDTYPE>&, const int, const int, const GIDTYPE, bool) ;
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes our sierra GID64 build, but is the GIDTYPE key type important enough to instantiate here?  Or do we want even more types instantiated? 


I think only the const host_device_ptr GIDTYPE BinarySearch is needed, but I added the others for symmetry.