### PR TITLE
Allow failure for builds

### DIFF
--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -35,6 +35,7 @@ ibm_clang_9:
   variables:
     SPEC: " %clang@9.0.0ibm"
   extends: .build_and_test_on_lassen
+  allow_failure: true
 
 ibm_clang_9_gcc_8:
   variables:
@@ -55,6 +56,7 @@ ibm_clang_9_cuda:
 #    SPEC: "+cuda +allow-unsupported-compilers cuda_arch=70 +tests %clang@9.0.0ibm^cuda@10.1.168 ^cmake@3.14.5"
     SPEC: "+cpp14 +cuda +allow-unsupported-compilers cuda_arch=70 %clang@9.0.0ibm^cuda@10.1.168 ^cmake@3.14.5"
   extends: .build_and_test_on_lassen
+  allow_failure: true
 
 #TODO - this is getting a linking error (The link line is getting -L/path/to/4.9.3 libraries in tests for chai)
 ibm_clang_9_gcc_8_cuda:

--- a/.gitlab/ruby.yml
+++ b/.gitlab/ruby.yml
@@ -55,20 +55,24 @@ clang_10:
   variables:
     SPEC: "%clang@10.0.1+tests"
   extends: .build_and_test_on_ruby
+  allow_failure: true
 
 clang_9:
   variables:
     SPEC: "%clang@9.0.0+tests"
   extends: .build_and_test_on_ruby
+  allow_failure: true
 
 gcc_8_1_0:
   variables:
     SPEC: "%gcc@8.1.0+tests"
   extends: .build_and_test_on_ruby
+  allow_failure: true
 
 #intel takes  a long time to link Loop Fuser tests, so we disable tests for this compiler
 icpc_19_0_4:
   variables:
     SPEC: " %intel@19.0.4"
   extends: .build_and_test_on_ruby
+  allow_failure: true
 


### PR DESCRIPTION
Lots of rework needs to be done for the GitLab CI due to changes in operating system and compilers and spack. For now, we will allow merge requests to proceed even if the builds fail.