### PR TITLE
Use public instead of private member for construction from different templates

### DIFF
--- a/src/care/host_ptr.h
+++ b/src/care/host_ptr.h
@@ -72,7 +72,7 @@ namespace care {
          ///
          template <bool B = std::is_const<T>::value,
                    typename std::enable_if<B, int>::type = 1>
-         host_ptr<T>(host_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr.m_ptr) {}
+         host_ptr<T>(host_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr.data()) {}
 
          ///
          /// @author Peter Robinson

--- a/src/care/local_ptr.h
+++ b/src/care/local_ptr.h
@@ -67,7 +67,7 @@ namespace care {
          ///
          template <bool B = std::is_const<T>::value,
                    typename std::enable_if<B, int>::type = 1>
-         CARE_HOST_DEVICE local_ptr<T>(local_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr.m_ptr) {}
+         CARE_HOST_DEVICE local_ptr<T>(local_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr.data()) {}
 
          ///
          /// @author Peter Robinson


### PR DESCRIPTION
Use `data()` member instead of `m_ptr` when constructing `host_ptr<const T>` from `host_ptr<T>` or `local_ptr<const T>` from local_ptr<T>`. Since these are different templates, public members should be used instead of private ones.