### PR TITLE
Fix bug in KeyValueSorter

### DIFF
--- a/src/care/KeyValueSorter_impl.h
+++ b/src/care/KeyValueSorter_impl.h
@@ -174,15 +174,6 @@ CARE_INLINE void sortKeyValueArrays(host_device_ptr<KeyT> & keys,
 
    keyValues.free();
 
-   // Free stale arrays
-   if (m_keys) {
-      m_keys.free();
-   }
-
-   if (m_values) {
-      m_values.free();
-   }
-
 #endif // defined(CARE_GPUCC)
 
 }


### PR DESCRIPTION
Fix after #234. sortKeyValueArrays is a generic method that does a simultaneous sort (it's not part of the KeyValueSorter class, so it can't access KeyValueSorter's data).