### PR TITLE
Fix loop fuser with RAJA v2024.02.2 and newer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,11 @@ in this file.
 
 The format of this file is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Version ?] - Release date ?
+
+### Fixed
+- Replaced loop\_work alias with seq\_work (loop\_work was removed in RAJA v2024.02.2)
+
 ## [Version 0.13.2] - Release date 2024-07-29
 
 ### Changed

--- a/src/care/LoopFuser.h
+++ b/src/care/LoopFuser.h
@@ -26,6 +26,8 @@ constexpr double CARE_DEFAULT_PHASE = -FLT_MAX/2.0;
 
 #if CARE_ENABLE_LOOP_FUSER
 
+#include "RAJA/RAJA.hpp"
+
 #include "umpire/Allocator.hpp"
 #include "umpire/TypedAllocator.hpp"
 
@@ -581,11 +583,11 @@ class LoopFuser : public FusedActions {
                                  RAJA::constant_stride_array_of_objects >;
 #else
       using workgroup_policy = RAJA::WorkGroupPolicy <
-                                 RAJA::loop_work,
+                                 RAJA::seq_work,
                                  RAJA::ordered,
                                  RAJA::ragged_array_of_objects >;
       using workgroup_ordered_policy = RAJA::WorkGroupPolicy <
-                                 RAJA::loop_work,
+                                 RAJA::seq_work,
                                  RAJA::ordered,
                                  RAJA::ragged_array_of_objects >;
 #endif


### PR DESCRIPTION
* loop_work alias has now been removed. seq_work should be used instead.