### PR TITLE
Update toolchains on tioga, lassen, ruby and poodle

### DIFF
--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -17,12 +17,7 @@
 # project. We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS}
 # So that the comparison with the original job is easier.
 
-# Override job with old cuda to allow it to fail.
-clang_12_0_1_ibm_gcc_8_3_1_cuda_10_1_243:
-  variables:
-    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %clang@12.0.1.ibm.gcc.8.3.1 ^cuda@10.1.243+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
-  extends: .job_on_lassen
-  allow_failure: true
+# No overridden jobs so far.
 
 ############
 # Extra jobs


### PR DESCRIPTION
- [x] Remove Intel 19
- [x] Update to Intel 2023
- [x] ~~Update corona to ROCm 6.0.2~~ -> same error as with tioga, need ROCm 6.1.x , reverted to ROCm 5.7.1
- [x] Update tioga to ROCm 6.1.2
- [x] Remove CUDA 10 job (blueos system default is now 11.2.0)