### PR TITLE
Bugfix/probinso/facekey device

### DIFF
--- a/src/care/SortFuser.h
+++ b/src/care/SortFuser.h
@@ -275,7 +275,7 @@ namespace care {
       
       // do the unique of the concatenated sort result
       int outLen;
-      care::uniqArray(RAJAExec{}, m_concatenated_result, m_total_length, concatenated_out, outLen);
+      care::uniqArray(RAJAExec{}, reinterpret_cast<host_device_ptr<const T>&>(m_concatenated_result), m_total_length, concatenated_out, outLen);
       
       /// determine new offsets by looking for boundaries in max_range
       host_device_ptr<int> out_offsets(m_num_arrays+1, "out_offsets");

--- a/src/care/algorithm_decl.h
+++ b/src/care/algorithm_decl.h
@@ -346,14 +346,13 @@ void sortArray(RAJADeviceExec, care::host_device_ptr<T, Accessor> &Array, size_t
 
 #endif // defined(CARE_PARALLEL_DEVICE)
 
-// TODO should this have an unused noCopy parameter?
 template <typename T, template<class A> class Accessor = care::CARE_DEFAULT_ACCESSOR>
-void uniqArray(RAJA::seq_exec, care::host_device_ptr<T, Accessor> Array, size_t len, care::host_device_ptr<T, Accessor> & outArray, int & newLen);
+void uniqArray(RAJA::seq_exec, care::host_device_ptr<const T, Accessor> Array, size_t len, care::host_device_ptr<T, Accessor> & outArray, int & newLen);
 template <typename T, template<class A> class Accessor = care::CARE_DEFAULT_ACCESSOR>
 int uniqArray(RAJA::seq_exec exec, care::host_device_ptr<T, Accessor> & Array, size_t len, bool noCopy=false);
 #ifdef CARE_PARALLEL_DEVICE
 template <typename T, template<class A> class Accessor = care::CARE_DEFAULT_ACCESSOR>
-void uniqArray(RAJADeviceExec, care::host_device_ptr<T, Accessor>  Array, size_t len, care::host_device_ptr<T, Accessor> & outArray, int & outLen, bool noCopy=false);
+void uniqArray(RAJADeviceExec, care::host_device_ptr<const T, Accessor>  Array, size_t len, care::host_device_ptr<T, Accessor> & outArray, int & outLen);
 template <typename T, template<class A> class Accessor = care::CARE_DEFAULT_ACCESSOR>
 int uniqArray(RAJADeviceExec exec, care::host_device_ptr<T, Accessor> & Array, size_t len, bool noCopy=false);
 #endif // defined(CARE_PARALLEL_DEVICE)

--- a/src/care/algorithm_impl.h
+++ b/src/care/algorithm_impl.h
@@ -471,7 +471,7 @@ CARE_HOST_DEVICE CARE_INLINE int BinarySearch(const T *map, const int start,
 
    while (khi-klo > 1) {
       k = (khi+klo) >> 1 ;
-      if (map[k] == num) {
+      if (! (map[k] < num) && !(num < map[k])) {
          if (returnUpperBound) {
             khi = k+1;
             klo = k;
@@ -481,7 +481,7 @@ CARE_HOST_DEVICE CARE_INLINE int BinarySearch(const T *map, const int start,
             return k ;
          }
       }
-      else if (map[k] > num) {
+      else if (num < map[k]) {
          khi = k ;
       }
       else {
@@ -491,19 +491,19 @@ CARE_HOST_DEVICE CARE_INLINE int BinarySearch(const T *map, const int start,
    if (returnUpperBound) {
       k = klo;
       // the lower option bounds num
-      if (map[k] > num) {
+      if (num < map[k]) {
          return k;
       }
       // the upper option is within the range of the map index set
       if (khi < start + mapSize) {
          // Note: fix for last test in TEST(algorithm, binarysearch). This algorithm has failed to pick up the upper
          // bound above 1 in the array {0, 1, 1, 1, 1, 1, 6}. Having 1 repeated confused the algorithm.
-         while ((khi < start + mapSize) && (map[khi] == num)) {
+         while ((khi < start + mapSize) && (!(map[khi] <  num) && !(num < map[khi]))) {
             ++khi;
          }
 
          // the upper option bounds num
-         if ((khi < start + mapSize) && (map[khi] > num)) {
+         if ((khi < start + mapSize) && (num < map[khi])) {
             return khi;
          }
          // neither the upper or lower option bound num
@@ -514,8 +514,8 @@ CARE_HOST_DEVICE CARE_INLINE int BinarySearch(const T *map, const int start,
          return -1;
       }
    }
-
-   if (map[--k] == num) {
+   --k;
+   if (!(map[k] < num) && !(num < map[k])) {
       return k ;
    }
    else {

--- a/src/care/algorithm_impl.h
+++ b/src/care/algorithm_impl.h
@@ -449,6 +449,10 @@ CARE_INLINE void IntersectArrays(RAJA::seq_exec exec,
  *             If returnUpperBound is set to true, this will return the
  *             index corresponding to the earliest entry that is greater
  *             than num.
+ *
+ *             @NOTE: Intentionally implemented this using only the '<'
+ *             operator to follow weak strict ordering semantics.
+ *
  ************************************************************************/
 
 template <typename T>

--- a/src/care/algorithm_impl.h
+++ b/src/care/algorithm_impl.h
@@ -547,8 +547,8 @@ CARE_HOST_DEVICE CARE_INLINE int BinarySearch(const care::host_device_ptr<const 
  *             scan.
   ************************************************************************/
 template <typename T, template<class A> class Accessor>
-CARE_INLINE void uniqArray(RAJADeviceExec, care::host_device_ptr<T, Accessor>  Array, size_t len,
-                           care::host_device_ptr<T, Accessor> & outArray, int & outLen, bool noCopy)
+CARE_INLINE void uniqArray(RAJADeviceExec, care::host_device_ptr<const T, Accessor>  Array, size_t len,
+                           care::host_device_ptr<T, Accessor> & outArray, int & outLen)
 {
    care::host_device_ptr<int> uniq(len+1,"uniqArray uniq");
    fill_n(uniq, len+1, 0);
@@ -582,7 +582,7 @@ CARE_INLINE int uniqArray(RAJADeviceExec exec, care::host_device_ptr<T, Accessor
 {
    care::host_device_ptr<T, Accessor> tmp;
    int newLen;
-   uniqArray(exec, Array, len, tmp, newLen);
+   uniqArray<T, Accessor>(exec, Array, len, tmp, newLen);
    if (noCopy) {
       Array.free();
       Array = tmp;
@@ -602,11 +602,11 @@ CARE_INLINE int uniqArray(RAJADeviceExec exec, care::host_device_ptr<T, Accessor
  * Purpose   : CPU version of uniqArray.
   ************************************************************************/
 template <typename T, template<class A> class Accessor>
-CARE_INLINE void uniqArray(RAJA::seq_exec, care::host_device_ptr<T, Accessor> Array, size_t len,
+CARE_INLINE void uniqArray(RAJA::seq_exec, care::host_device_ptr<const T, Accessor> Array, size_t len,
                            care::host_device_ptr<T, Accessor> & outArray, int & newLen)
 {
-   CHAIDataGetter<T, RAJA::seq_exec> getter {};
-   const auto * rawData = getter.getConstRawArrayData(Array);
+   CHAIDataGetter<const T, RAJA::seq_exec> getter {};
+   auto * rawData = getter.getConstRawArrayData(Array);
    newLen = 0 ;
    care::host_ptr<T> arrout = nullptr ;
    outArray = nullptr;

--- a/src/care/care_inst.h
+++ b/src/care/care_inst.h
@@ -215,14 +215,14 @@ CARE_HOST_DEVICE int BinarySearch(const care::host_device_ptr<const GIDTYPE>&, c
 #ifdef CARE_PARALLEL_DEVICE
 
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJADeviceExec, care::host_device_ptr<int, care::NoOpAccessor>, size_t, care::host_device_ptr<int, care::NoOpAccessor> &, int &, bool) ;
+void uniqArray(RAJADeviceExec, care::host_device_ptr<int const, care::NoOpAccessor>, size_t, care::host_device_ptr<int, care::NoOpAccessor> &, int &) ;
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJADeviceExec, care::host_device_ptr<float, care::NoOpAccessor>, size_t, care::host_device_ptr<float, care::NoOpAccessor> &, int &, bool) ;
+void uniqArray(RAJADeviceExec, care::host_device_ptr<float const, care::NoOpAccessor>, size_t, care::host_device_ptr<float, care::NoOpAccessor> &, int &) ;
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJADeviceExec, care::host_device_ptr<double, care::NoOpAccessor>, size_t, care::host_device_ptr<double, care::NoOpAccessor> &, int &, bool) ;
+void uniqArray(RAJADeviceExec, care::host_device_ptr<double const, care::NoOpAccessor>, size_t, care::host_device_ptr<double, care::NoOpAccessor> &, int &) ;
 #if CARE_HAVE_LLNL_GLOBALID
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJADeviceExec, care::host_device_ptr<globalID, care::NoOpAccessor>, size_t, care::host_device_ptr<globalID, care::NoOpAccessor> &, int &, bool) ;
+void uniqArray(RAJADeviceExec, care::host_device_ptr<globalID const, care::NoOpAccessor>, size_t, care::host_device_ptr<globalID, care::NoOpAccessor> &, int &) ;
 #endif
 
 CARE_EXTERN template CARE_DLL_API
@@ -237,14 +237,14 @@ int uniqArray(RAJADeviceExec, care::host_device_ptr<globalID, care::NoOpAccessor
 #endif
 
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJADeviceExec, care::host_device_ptr<int, care::RaceConditionAccessor>, size_t, care::host_device_ptr<int, care::RaceConditionAccessor> &, int &, bool) ;
+void uniqArray(RAJADeviceExec, care::host_device_ptr<int const, care::RaceConditionAccessor>, size_t, care::host_device_ptr<int, care::RaceConditionAccessor> &, int &) ;
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJADeviceExec, care::host_device_ptr<float, care::RaceConditionAccessor>, size_t, care::host_device_ptr<float, care::RaceConditionAccessor> &, int &, bool) ;
+void uniqArray(RAJADeviceExec, care::host_device_ptr<float const, care::RaceConditionAccessor>, size_t, care::host_device_ptr<float, care::RaceConditionAccessor> &, int &) ;
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJADeviceExec, care::host_device_ptr<double, care::RaceConditionAccessor>, size_t, care::host_device_ptr<double, care::RaceConditionAccessor> &, int &, bool) ;
+void uniqArray(RAJADeviceExec, care::host_device_ptr<double const, care::RaceConditionAccessor>, size_t, care::host_device_ptr<double, care::RaceConditionAccessor> &, int &) ;
 #if CARE_HAVE_LLNL_GLOBALID
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJADeviceExec, care::host_device_ptr<globalID, care::RaceConditionAccessor>, size_t, care::host_device_ptr<globalID, care::RaceConditionAccessor> &, int &, bool) ;
+void uniqArray(RAJADeviceExec, care::host_device_ptr<globalID const, care::RaceConditionAccessor>, size_t, care::host_device_ptr<globalID, care::RaceConditionAccessor> &, int &) ;
 #endif
 
 CARE_EXTERN template CARE_DLL_API
@@ -261,14 +261,14 @@ int uniqArray(RAJADeviceExec, care::host_device_ptr<globalID, care::RaceConditio
 #endif // defined(CARE_PARALLEL_DEVICE)
 
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJA::seq_exec, care::host_device_ptr<int, care::NoOpAccessor>, size_t, care::host_device_ptr<int, care::NoOpAccessor> &, int &) ;
+void uniqArray(RAJA::seq_exec, care::host_device_ptr<int const, care::NoOpAccessor>, size_t, care::host_device_ptr<int, care::NoOpAccessor> &, int &) ;
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJA::seq_exec, care::host_device_ptr<float, care::NoOpAccessor>, size_t, care::host_device_ptr<float, care::NoOpAccessor> &, int &) ;
+void uniqArray(RAJA::seq_exec, care::host_device_ptr<float const, care::NoOpAccessor>, size_t, care::host_device_ptr<float, care::NoOpAccessor> &, int &) ;
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJA::seq_exec, care::host_device_ptr<double, care::NoOpAccessor>, size_t, care::host_device_ptr<double, care::NoOpAccessor> &, int &) ;
+void uniqArray(RAJA::seq_exec, care::host_device_ptr<double const, care::NoOpAccessor>, size_t, care::host_device_ptr<double, care::NoOpAccessor> &, int &) ;
 #if CARE_HAVE_LLNL_GLOBALID
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJA::seq_exec, care::host_device_ptr<globalID, care::NoOpAccessor>, size_t, care::host_device_ptr<globalID, care::NoOpAccessor> &, int &) ;
+void uniqArray(RAJA::seq_exec, care::host_device_ptr<globalID const, care::NoOpAccessor>, size_t, care::host_device_ptr<globalID, care::NoOpAccessor> &, int &) ;
 #endif
 
 CARE_EXTERN template CARE_DLL_API
@@ -283,14 +283,14 @@ int uniqArray(RAJA::seq_exec exec, care::host_device_ptr<globalID, care::NoOpAcc
 #endif
 
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJA::seq_exec, care::host_device_ptr<int, care::RaceConditionAccessor>, size_t, care::host_device_ptr<int, care::RaceConditionAccessor> &, int &) ;
+void uniqArray(RAJA::seq_exec, care::host_device_ptr<int const, care::RaceConditionAccessor>, size_t, care::host_device_ptr<int, care::RaceConditionAccessor> &, int &) ;
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJA::seq_exec, care::host_device_ptr<float, care::RaceConditionAccessor>, size_t, care::host_device_ptr<float, care::RaceConditionAccessor> &, int &) ;
+void uniqArray(RAJA::seq_exec, care::host_device_ptr<float const, care::RaceConditionAccessor>, size_t, care::host_device_ptr<float, care::RaceConditionAccessor> &, int &) ;
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJA::seq_exec, care::host_device_ptr<double, care::RaceConditionAccessor>, size_t, care::host_device_ptr<double, care::RaceConditionAccessor> &, int &) ;
+void uniqArray(RAJA::seq_exec, care::host_device_ptr<double const, care::RaceConditionAccessor>, size_t, care::host_device_ptr<double, care::RaceConditionAccessor> &, int &) ;
 #if CARE_HAVE_LLNL_GLOBALID
 CARE_EXTERN template CARE_DLL_API
-void uniqArray(RAJA::seq_exec, care::host_device_ptr<globalID, care::RaceConditionAccessor>, size_t, care::host_device_ptr<globalID, care::RaceConditionAccessor> &, int &) ;
+void uniqArray(RAJA::seq_exec, care::host_device_ptr<globalID const, care::RaceConditionAccessor>, size_t, care::host_device_ptr<globalID, care::RaceConditionAccessor> &, int &) ;
 #endif
 
 CARE_EXTERN template CARE_DLL_API


### PR DESCRIPTION
Const correctness fix in uniqArray API.

Strictly use '<' in care::BinarySearch.