### PR TITLE
Add additional atomics and tsan only atomics

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,12 @@ in this file.
 
 The format of this file is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] - Release date YYYY-MM-DD
+
+### Added
+- Added ATOMIC\_SUB, ATOMIC\_LOAD, ATOMIC\_STORE, ATOMIC\_EXCHANGE, and ATOMIC\_CAS macros.
+- Added TSAN\_ONLY\_ATOMIC\_\* macros to suppress tsan data race reports. Controlled by CARE\_ENABLE\_TSAN\_ONLY\_ATOMICS configuration option.
+
 ## [Version 0.14.1] - Release date 2024-10-15
 
 ### Fixed

--- a/cmake/SetupOptions.cmake
+++ b/cmake/SetupOptions.cmake
@@ -32,6 +32,8 @@ option(CARE_NEVER_USE_RAJA_PARALLEL_SCAN "Disable RAJA parallel scans in SCAN lo
 option(CARE_ENABLE_FUSER_BIN_32 "Enable the 32 register fusible loop bin." OFF)
 option(CARE_ENABLE_PARALLEL_LOOP_BACKWARDS "Reverse the start and end for parallel loops." OFF)
 option(CARE_ENABLE_STALE_DATA_CHECK "Enable checking for stale host data. Only applicable for GPU (or GPU simulation) builds." OFF)
+# TODO: Investigate correctness and performance impact of this option
+option(CARE_ENABLE_TSAN_ONLY_ATOMICS "Enable atomics for TSAN build." OFF)
 
 # Extra components
 cmake_dependent_option(CARE_ENABLE_TESTS "Build CARE tests"

--- a/cmake/SetupOptions.cmake
+++ b/cmake/SetupOptions.cmake
@@ -33,7 +33,7 @@ option(CARE_ENABLE_FUSER_BIN_32 "Enable the 32 register fusible loop bin." OFF)
 option(CARE_ENABLE_PARALLEL_LOOP_BACKWARDS "Reverse the start and end for parallel loops." OFF)
 option(CARE_ENABLE_STALE_DATA_CHECK "Enable checking for stale host data. Only applicable for GPU (or GPU simulation) builds." OFF)
 # TODO: Investigate correctness and performance impact of this option
-option(CARE_ENABLE_TSAN_ONLY_ATOMICS "Enable atomics for TSAN build." OFF)
+option(CARE_ENABLE_TSAN_ONLY_ATOMICS "Enable atomics for ThreadSanitizer (TSAN) build." OFF)
 
 # Extra components
 cmake_dependent_option(CARE_ENABLE_TESTS "Build CARE tests"

--- a/src/care/atomic.h
+++ b/src/care/atomic.h
@@ -32,10 +32,10 @@ using RAJAAtomic = RAJA::auto_atomic;
 /// setting the same variable to the same value).
 ///
 /// WARNING: The returned previous value for the TSAN_ONLY_ATOMIC_* macros
-///          should not be used in a parallel context, since another thread
-///          may have modified the value at the given memory location in
-///          between the current thread's read and write. If the return value
-///          is needed, use the ATOMIC_* macros instead.
+///          should generally not be used in a parallel context, since
+///          another thread may have modified the value at the given memory
+///          location in between the current thread's read and write. If the
+///          return value is needed, use the ATOMIC_* macros instead.
 ///
 /// TODO: Evaluate whether the compiler actually does the right thing without
 ///       atomics and whether using atomics detracts from performance.

--- a/src/care/atomic.h
+++ b/src/care/atomic.h
@@ -8,15 +8,68 @@
 #ifndef CARE_ATOMIC_H
 #define CARE_ATOMIC_H
 
+#include "care/config.h"
 #include "RAJA/RAJA.hpp"
 
 using RAJAAtomic = RAJA::auto_atomic;
 
-#define ATOMIC_ADD(ref, inc) RAJA::atomicAdd<RAJAAtomic>(&(ref), inc)
-#define ATOMIC_MIN(ref, val) RAJA::atomicMin<RAJAAtomic>(&(ref), val)
-#define ATOMIC_MAX(ref, val) RAJA::atomicMax<RAJAAtomic>(&(ref), val)
-#define ATOMIC_OR(ref, val)  RAJA::atomicOr<RAJAAtomic>(&(ref), val)
-#define ATOMIC_AND(ref, val) RAJA::atomicAnd<RAJAAtomic>(&(ref), val)
-#define ATOMIC_XOR(ref, val) RAJA::atomicXor<RAJAAtomic>(&(ref), val)
+#define ATOMIC_ADD(ref, inc)          RAJA::atomicAdd<RAJAAtomic>(&(ref), inc)
+#define ATOMIC_SUB(ref, inc)          RAJA::atomicSub<RAJAAtomic>(&(ref), inc)
+#define ATOMIC_MIN(ref, val)          RAJA::atomicMin<RAJAAtomic>(&(ref), val)
+#define ATOMIC_MAX(ref, val)          RAJA::atomicMax<RAJAAtomic>(&(ref), val)
+#define ATOMIC_OR(ref, val)           RAJA::atomicOr<RAJAAtomic>(&(ref), val)
+#define ATOMIC_AND(ref, val)          RAJA::atomicAnd<RAJAAtomic>(&(ref), val)
+#define ATOMIC_XOR(ref, val)          RAJA::atomicXor<RAJAAtomic>(&(ref), val)
+#define ATOMIC_LOAD(ref)              RAJA::atomicLoad<RAJAAtomic>(&(ref))
+#define ATOMIC_STORE(ref, val)        RAJA::atomicStore<RAJAAtomic>(&(ref), val)
+#define ATOMIC_EXCHANGE(ref, val)     RAJA::atomicExchange<RAJAAtomic>(&(ref), val)
+#define ATOMIC_CAS(ref, compare, val) RAJA::atomicCAS<RAJAAtomic>(&(ref), compare, val)
+
+///
+/// Macros that use atomics for a ThreadSanitizer build to avoid false
+/// positives, but otherwise do a non-atomic operation (for cases where
+/// the order of execution does not matter, such as multiple threads
+/// setting the same variable to the same value).
+///
+/// WARNING: The returned previous value for the TSAN_ONLY_ATOMIC_* macros
+///          should not be used in a parallel context, since another thread
+///          may have modified the value at the given memory location in
+///          between the current thread's read and write. If the return value
+///          is needed, use the ATOMIC_* macros instead.
+///
+/// TODO: Evaluate whether the compiler actually does the right thing without
+///       atomics and whether using atomics detracts from performance.
+///
+#if defined(CARE_ENABLE_TSAN_ONLY_ATOMICS)
+
+#define TSAN_ONLY_ATOMIC_ADD(ref, inc)          ATOMIC_ADD(ref, inc)
+#define TSAN_ONLY_ATOMIC_SUB(ref, inc)          ATOMIC_SUB(ref, inc)
+#define TSAN_ONLY_ATOMIC_MIN(ref, val)          ATOMIC_MIN(ref, val)
+#define TSAN_ONLY_ATOMIC_MAX(ref, val)          ATOMIC_MAX(ref, val)
+#define TSAN_ONLY_ATOMIC_OR(ref, val)           ATOMIC_OR(ref, val)
+#define TSAN_ONLY_ATOMIC_AND(ref, val)          ATOMIC_AND(ref, val)
+#define TSAN_ONLY_ATOMIC_XOR(ref, val)          ATOMIC_XOR(ref, val)
+#define TSAN_ONLY_ATOMIC_LOAD(ref)              ATOMIC_LOAD(ref)
+#define TSAN_ONLY_ATOMIC_STORE(ref, val)        ATOMIC_STORE(ref, val)
+#define TSAN_ONLY_ATOMIC_EXCHANGE(ref, val)     ATOMIC_EXCHANGE(ref, val)
+#define TSAN_ONLY_ATOMIC_CAS(ref, compare, val) ATOMIC_CAS(ref, compare, val)
+
+#else
+
+using TSANOnlyAtomic = RAJA::seq_atomic;
+
+#define TSAN_ONLY_ATOMIC_ADD(ref, inc)          RAJA::atomicAdd<TSANOnlyAtomic>(&(ref), inc)
+#define TSAN_ONLY_ATOMIC_SUB(ref, inc)          RAJA::atomicSub<TSANOnlyAtomic>(&(ref), inc)
+#define TSAN_ONLY_ATOMIC_MIN(ref, val)          RAJA::atomicMin<TSANOnlyAtomic>(&(ref), val)
+#define TSAN_ONLY_ATOMIC_MAX(ref, val)          RAJA::atomicMax<TSANOnlyAtomic>(&(ref), val)
+#define TSAN_ONLY_ATOMIC_OR(ref, val)           RAJA::atomicOr<TSANOnlyAtomic>(&(ref), val)
+#define TSAN_ONLY_ATOMIC_AND(ref, val)          RAJA::atomicAnd<TSANOnlyAtomic>(&(ref), val)
+#define TSAN_ONLY_ATOMIC_XOR(ref, val)          RAJA::atomicXor<TSANOnlyAtomic>(&(ref), val)
+#define TSAN_ONLY_ATOMIC_LOAD(ref)              RAJA::atomicLoad<TSANOnlyAtomic>(&(ref))
+#define TSAN_ONLY_ATOMIC_STORE(ref, val)        RAJA::atomicStore<TSANOnlyAtomic>(&(ref), val)
+#define TSAN_ONLY_ATOMIC_EXCHANGE(ref, val)     RAJA::atomicExchange<TSANOnlyAtomic>(&(ref), val)
+#define TSAN_ONLY_ATOMIC_CAS(ref, compare, val) RAJA::atomicCAS<TSANOnlyAtomic>(&(ref), compare, val)
+
+#endif
 
 #endif // CARE_ATOMIC_H

--- a/src/care/config.h.in
+++ b/src/care/config.h.in
@@ -28,6 +28,7 @@
 #cmakedefine CARE_GPU_MEMORY_IS_ACCESSIBLE_ON_CPU
 #cmakedefine CARE_ENABLE_STALE_DATA_CHECK
 #cmakedefine CARE_ENABLE_RACE_DETECTION
+#cmakedefine CARE_ENABLE_TSAN_ONLY_ATOMICS
 
 // Optional dependencies
 #cmakedefine01 CARE_HAVE_LLNL_GLOBALID


### PR DESCRIPTION
* Add ATOMIC_SUB, ATOMIC_LOAD, ATOMIC_STORE, ATOMIC_EXCHANGE, and ATOMIC_CAS
* Add TSAN_ONLY_ATOMIC_* macros to suppress data races reported by tsan (such as multiple threads setting an address to the same value)
* Add CARE_ENABLE_TSAN_ONLY_ATOMICS configuration option to control whether the TSAN_ONLY_ATOMIC_* macros use atomics behind the scenes.