### PR TITLE
Replace getPointer method with data method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,12 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 - Added ATOMIC\_SUB, ATOMIC\_LOAD, ATOMIC\_STORE, ATOMIC\_EXCHANGE, and ATOMIC\_CAS macros.
 - Added TSAN\_ONLY\_ATOMIC\_\* macros to suppress tsan data race reports. Controlled by CARE\_ENABLE\_TSAN\_ONLY\_ATOMICS configuration option.
 
+### Changed
+- Renamed host\_device\_ptr::getPointer to host\_device\_ptr::data.
+
+### Fixed
+- Replaced calls to chai::ManagedArray::getPointer (previously deprecated and now removed) with calls to chai::ManagedArray::data.
+
 ## [Version 0.14.1] - Release date 2024-10-15
 
 ### Fixed

--- a/src/care/CHAIDataGetter.h
+++ b/src/care/CHAIDataGetter.h
@@ -28,12 +28,12 @@ class CHAIDataGetter {
       T * getRawArrayData(chai::ManagedArray<T> data) {
          data.move(chai::CPU);
          data.registerTouch(chai::CPU);
-         return (T*)data.getPointer(chai::CPU);
+         return (T*)data.data(chai::CPU);
       }
 
       const T * getConstRawArrayData(chai::ManagedArray<T> data) {
          data.move(chai::CPU);
-         return (const T*)data.getPointer(chai::CPU);
+         return (const T*)data.data(chai::CPU);
       }
 
       static const auto ChaiPolicy = chai::CPU;
@@ -49,12 +49,12 @@ class CHAIDataGetter<T, RAJADeviceExec> {
       T * getRawArrayData(chai::ManagedArray<T> data) {
          data.move(chai::GPU);
          data.registerTouch(chai::GPU);
-         return (T*)data.getPointer(chai::GPU);
+         return (T*)data.data(chai::GPU);
       }
 
       const T * getConstRawArrayData(chai::ManagedArray<T> data) {
          data.move(chai::GPU);
-         return (const T*)data.getPointer(chai::GPU);
+         return (const T*)data.data(chai::GPU);
       }
 
       static const auto ChaiPolicy = chai::GPU;
@@ -70,12 +70,12 @@ class CHAIDataGetter<globalID, RAJADeviceExec> {
       GIDTYPE * getRawArrayData(chai::ManagedArray<globalID> data) {
          data.move(chai::GPU);
          data.registerTouch(chai::GPU);
-         return (GIDTYPE*)data.getPointer(chai::GPU);
+         return (GIDTYPE*)data.data(chai::GPU);
       }
 
       const GIDTYPE * getConstRawArrayData(chai::ManagedArray<globalID> data) {
          data.move(chai::GPU);
-         return (GIDTYPE*)data.getPointer(chai::GPU);
+         return (GIDTYPE*)data.data(chai::GPU);
       }
 
       static const auto ChaiPolicy = chai::GPU;
@@ -95,12 +95,12 @@ class CHAIDataGetter<globalID, RAJA::seq_exec> {
       GIDTYPE * getRawArrayData(chai::ManagedArray<globalID> data) {
          data.move(chai::CPU);
          data.registerTouch(chai::CPU);
-         return (GIDTYPE*)data.getPointer(chai::CPU);
+         return (GIDTYPE*)data.data(chai::CPU);
       }
 
       const GIDTYPE * getConstRawArrayData(chai::ManagedArray<globalID> data) {
          data.move(chai::CPU);
-         return (GIDTYPE*)data.getPointer(chai::CPU);
+         return (GIDTYPE*)data.data(chai::CPU);
       }
 
       static const auto ChaiPolicy = chai::CPU;

--- a/src/care/SortFuser.h
+++ b/src/care/SortFuser.h
@@ -299,8 +299,8 @@ namespace care {
       // set up a 2D kernel, put per-array meta-data in pinned memory to eliminate cudaMemcpy's of the smaller dimension of data
       host_device_ptr<int> lengths(chai::ManagedArray<int>(m_num_arrays, chai::ZERO_COPY));
       host_device_ptr<host_device_ptr<int> > out_arrays(chai::ManagedArray<host_device_ptr<int>>(m_num_arrays, chai::ZERO_COPY));
-      host_ptr<int> pinned_lengths = lengths.getPointer(care::ZERO_COPY, false);
-      host_ptr<host_device_ptr<int>>  pinned_out_arrays = out_arrays.getPointer(care::ZERO_COPY, false);
+      host_ptr<int> pinned_lengths = lengths.data(care::ZERO_COPY, false);
+      host_ptr<host_device_ptr<int>>  pinned_out_arrays = out_arrays.data(care::ZERO_COPY, false);
       // initialized lengths, maxLength, and array of arrays for the 2D kernel
       int maxLength = 0;
       for (int a = 0; a < m_num_arrays; ++a ) {
@@ -316,7 +316,7 @@ namespace care {
       }
       // subtract out the offset, copy the result into individual arrays
       // (use of device pointer is to avoid clang-query rules that prevent capture of raw pointer)
-      device_ptr<int> dev_pinned_lengths = lengths.getPointer(ZERO_COPY, false);
+      device_ptr<int> dev_pinned_lengths = lengths.data(ZERO_COPY, false);
       CARE_LOOP_2D_STREAM_JAGGED(i, 0, maxLength, lengths, a, 0, m_num_arrays, iFlattened)  {
          result[i+out_offsets[a]] -= max_range*a;
          out_arrays[a][i] = result[i+out_offsets[a]];

--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -500,8 +500,11 @@ namespace care {
          return MA::pick((size_t) idx);
       }
 
-      CARE_HOST T* getPointer(ExecutionSpace space, bool moveToSpace = true) {
-         return MA::getPointer(chai::ExecutionSpace((int)space), moveToSpace);
+      using MA::data;
+      using MA::cdata;
+
+      CARE_HOST T* data(ExecutionSpace space, bool moveToSpace = true) {
+         return MA::data(chai::ExecutionSpace((int)space), moveToSpace);
       }
 
       CARE_HOST void registerTouch(ExecutionSpace space) {


### PR DESCRIPTION
* chai::ManagedArray::getPointer method was previously deprecated and has now been removed. Uses have been replaced with chai::ManagedArray::data.
* care::host_device_ptr::getPointer has been renamed to care::host_device_ptr::data for consistency.