### PR TITLE
Fix ambigous constructor call in TestKeyValueSorter

### DIFF
--- a/test/TestKeyValueSorter.cpp
+++ b/test/TestKeyValueSorter.cpp
@@ -115,7 +115,7 @@ TEST(KeyValueSorter, host_device_ptr_Constructor)
       data[4] = 3;
    } CARE_HOST_KERNEL_END
 
-   care::KeyValueSorter<size_t, int, RAJA::seq_exec> sorter(length, data);
+   care::KeyValueSorter<size_t, int, RAJA::seq_exec> sorter(length, care::host_device_ptr<const int>(data));
 
    CARE_SEQUENTIAL_LOOP(i, 0, length) {
       EXPECT_EQ(sorter.key(i), i);
@@ -233,7 +233,7 @@ GPU_TEST(KeyValueSorter, host_device_ptr_Constructor)
       data[4] = 3;
    } CARE_GPU_KERNEL_END
 
-   care::KeyValueSorter<size_t, int, RAJAExec> sorter(length, data);
+   care::KeyValueSorter<size_t, int, RAJAExec> sorter(length, care::host_device_ptr<const int>(data));
 
    CARE_SEQUENTIAL_LOOP(i, 0, length) {
       EXPECT_EQ(sorter.key(i), i);


### PR DESCRIPTION
* Fix ambiguous constructor call in TestKeyValueSorter
* We may need to consider the alternative of adding a constructor that takes care::host_device_ptr<T> and converts it to care::host_device_ptr<const T>
* Also, make sure that implicit casting between raw pointers and host_device_ptr is disabled