### PR TITLE
fix gpu errors

### DIFF
--- a/src/care/host_device_map.h
+++ b/src/care/host_device_map.h
@@ -86,17 +86,14 @@ namespace care {
          }
 
          // copy constructor 
-         host_device_map(host_device_map const & other) noexcept {
-            delete m_map;
-            delete m_size;
-            delete m_iterator;
-            delete m_next_iterator_index;
-            m_map = other.m_map;
-            m_size = other.m_size;
-            m_iterator = other.m_iterator;
-            m_next_iterator_index = other.m_next_iterator_index;
-            m_max_size = other.m_max_size;
-            m_signal = other.m_signal;
+         host_device_map(host_device_map const & other) noexcept :
+            m_map(other.m_map),
+            m_size(other.m_size),
+            m_iterator(other.m_iterator),
+            m_next_iterator_index(other.m_next_iterator_index),
+            m_max_size(other.m_max_size),
+            m_signal(other.m_signal)
+	 {
 	 }
 
          // move constructor

--- a/src/care/host_device_map.h
+++ b/src/care/host_device_map.h
@@ -221,7 +221,7 @@ namespace care {
          using int_ptr = care::host_device_ptr<int>;
          
          // default constructor
-         CARE_HOST_DEVICE host_device_map() noexcept {}
+         CARE_HOST_DEVICE host_device_map() noexcept {};
          
          // constructor taking max_entries
          host_device_map(size_t max_entries) : m_max_size(max_entries), m_signal(0), m_gpu_map{max_entries}   {
@@ -237,14 +237,13 @@ namespace care {
          }
 
          // copy constructor 
-         CARE_HOST_DEVICE host_device_map(host_device_map const & other) noexcept {
-            m_max_size = other.m_max_size;
-            m_signal = other.m_signal;
-            m_gpu_map = other.m_gpu_map;
-            m_size_ptr.free();
-            m_size_ptr = other.m_size_ptr;
-            other.m_size_ptr = nullptr;
-            m_size = other.m_size;
+         CARE_HOST_DEVICE host_device_map(host_device_map const & other) noexcept :
+            m_max_size{other.m_max_size},
+            m_signal{other.m_signal},
+            m_gpu_map{other.m_gpu_map},
+            m_size_ptr{other.m_size_ptr},
+            m_size{other.m_size}
+	 {
 	 }
 
          // move constructor
@@ -418,13 +417,13 @@ namespace care {
          }
          
          // copy constructor 
-         host_device_map(host_device_map const & other) noexcept {
-            delete m_size_ptr;
-            m_size_ptr = other.m_size_ptr;
-            m_size = other.m_size;
-            m_map = other.m_map;
-            m_max_size = other.m_max_size;
-            m_signal = other.m_signal;
+         host_device_map(host_device_map const & other) noexcept :
+            m_size_ptr(other.m_size_ptr),
+            m_size(other.m_size),
+            m_map(other.m_map),
+            m_max_size(other.m_max_size),
+            m_signal(other.m_signal)
+	 {
 	 }
 
          // move constructor

--- a/src/care/host_device_map.h
+++ b/src/care/host_device_map.h
@@ -66,7 +66,7 @@ namespace care {
    class host_device_map< key_type, mapped_type, RAJA::seq_exec> {
       public:
          // default constructor
-         host_device_map() noexcept = default;
+         host_device_map() noexcept {};
          
          // constructor taking max number of entries
          host_device_map(size_t max_entries) : host_device_map{} {
@@ -86,7 +86,18 @@ namespace care {
          }
 
          // copy constructor 
-         host_device_map(host_device_map const & other) noexcept = default;
+         host_device_map(host_device_map const & other) noexcept {
+            delete m_map;
+            delete m_size;
+            delete m_iterator;
+            delete m_next_iterator_index;
+            m_map = other.m_map;
+            m_size = other.m_size;
+            m_iterator = other.m_iterator;
+            m_next_iterator_index = other.m_next_iterator_index;
+            m_max_size = other.m_max_size;
+            m_signal = other.m_signal;
+	 }
 
          // move constructor
          host_device_map(host_device_map && other) noexcept  {
@@ -210,7 +221,7 @@ namespace care {
          using int_ptr = care::host_device_ptr<int>;
          
          // default constructor
-         CARE_HOST_DEVICE host_device_map() noexcept {};
+         CARE_HOST_DEVICE host_device_map() noexcept {}
          
          // constructor taking max_entries
          host_device_map(size_t max_entries) : m_max_size(max_entries), m_signal(0), m_gpu_map{max_entries}   {
@@ -226,13 +237,14 @@ namespace care {
          }
 
          // copy constructor 
-         CARE_HOST_DEVICE host_device_map(host_device_map const & other) noexcept :
-            m_max_size{other.m_max_size},
-            m_signal{other.m_signal},
-            m_gpu_map{other.m_gpu_map},
-            m_size_ptr{other.m_size_ptr},
-            m_size{other.m_size}
-	 {
+         CARE_HOST_DEVICE host_device_map(host_device_map const & other) noexcept {
+            m_max_size = other.m_max_size;
+            m_signal = other.m_signal;
+            m_gpu_map = other.m_gpu_map;
+            m_size_ptr.free();
+            m_size_ptr = other.m_size_ptr;
+            other.m_size_ptr = nullptr;
+            m_size = other.m_size;
 	 }
 
          // move constructor
@@ -387,7 +399,7 @@ namespace care {
    {
       public:
          // default constructor
-         host_device_map() noexcept = default;         
+         host_device_map() noexcept {};         
          
          // constructor
          host_device_map(size_t max_entries) : host_device_map{} {
@@ -406,9 +418,16 @@ namespace care {
          }
          
          // copy constructor 
-         host_device_map(host_device_map const & other) noexcept = default;
+         host_device_map(host_device_map const & other) noexcept {
+            delete m_size_ptr;
+            m_size_ptr = other.m_size_ptr;
+            m_size = other.m_size;
+            m_map = other.m_map;
+            m_max_size = other.m_max_size;
+            m_signal = other.m_signal;
+	 }
 
-	 // move constructor
+         // move constructor
          host_device_map(host_device_map && other)  noexcept {
             delete m_size_ptr;
             m_size_ptr = other.m_size_ptr;


### PR DESCRIPTION
Sometimes nvcc won't generate constructors/assignment operators when = default is used. The workaround is to explicitly define them.

See also a previous MR, https://github.com/LLNL/CARE/pull/292 . Some similar changes were made in that MR, but the same changes were needed elsewhere to resolve the errors.