### PR TITLE
Remove wrapper for make_managed_from_factory

### DIFF
--- a/src/care/managed_ptr.h
+++ b/src/care/managed_ptr.h
@@ -25,13 +25,6 @@ namespace care{
    inline managed_ptr<T> make_managed(Args&&... args) {
       return chai::make_managed<T>(std::forward<Args>(args)...);
    }
-
-   template <typename T,
-             typename F,
-             typename... Args>
-   inline managed_ptr<T> make_managed_from_factory(F&& f, Args&&... args) {
-      return chai::make_managed_from_factory<T>(std::forward<F>(f), std::forward<Args>(args)...);
-   }
 }
 
 #else // defined(CARE_ENABLE_MANAGED_PTR)


### PR DESCRIPTION
The make_managed_from_factory function is being removed from CHAI, so remove CARE's make_managed_from_factory wrapper function.