### PR TITLE
Miscellaneous bug fixes

### DIFF
--- a/src/care/KeyValueSorter_impl.h
+++ b/src/care/KeyValueSorter_impl.h
@@ -90,11 +90,6 @@ sortKeyValueArrays(host_device_ptr<KeyT> & keys,
    auto * rawKeyResult = keyGetter.getRawArrayData(keyResult);
    auto * rawValueResult = valueGetter.getRawArrayData(valueResult);
 
-   auto custom_comparator = [] CARE_HOST_DEVICE (decltype(*rawKeyData) lhs, decltype(*rawKeyData) rhs) {
-      return lhs < rhs;
-   };
-
-
    // Get the temp storage length
    char * d_temp_storage = nullptr;
    size_t temp_storage_bytes = 0;

--- a/src/care/algorithm_impl.h
+++ b/src/care/algorithm_impl.h
@@ -844,11 +844,16 @@ CARE_INLINE void sortArray(RAJA::seq_exec, care::host_device_ptr<T> &Array, size
 * Function  : sort_uniq(<T>_ptr)
 * Author(s) : Peter Robinson
 * Purpose   : Sorts and uniques an array.
+* @param    : e Execution policy
+* @param    : array: pointer to an array to sort and uniq
+* @param    : len: length of the array
+* @param    : noCopy. If true, implementation is free to store a completely new array at pointer
+*             If false, implementation will not mess with the underlying allocation of the new array
 **************************************************************************/
 template <typename T, typename Exec>
 CARE_INLINE void sort_uniq(Exec e, care::host_device_ptr<T> * array, int * len, bool noCopy)
 {
-   if ((*len) == 0) {
+   if ((*len) == 0 && noCopy) {
       if ((*array) != nullptr) {
          array->free();
          *array = nullptr;

--- a/src/care/algorithm_impl.h
+++ b/src/care/algorithm_impl.h
@@ -853,13 +853,15 @@ CARE_INLINE void sortArray(RAJA::seq_exec, care::host_device_ptr<T> &Array, size
 template <typename T, typename Exec>
 CARE_INLINE void sort_uniq(Exec e, care::host_device_ptr<T> * array, int * len, bool noCopy)
 {
-   if ((*len) == 0 && noCopy) {
-      if ((*array) != nullptr) {
+   if (*len == 0) {
+      if (noCopy && *array != nullptr) {
          array->free();
          *array = nullptr;
       }
+
       return;
    }
+
    /* first sort the array */
    sortArray<T>(e, *array, *len, 0, noCopy);
    /* then unique it */

--- a/src/care/host_device_map.h
+++ b/src/care/host_device_map.h
@@ -496,21 +496,23 @@ namespace care {
         // preallocate buffers for adding up to size elements
         void reserve(int max_size) { 
            if (m_max_size < max_size) {
-              if (m_size == 0) {
-                 m_map = std::move(KeyValueSorter<key_type, mapped_type, RAJA::seq_exec>{max_size}); 
-              }
-              else {
+              KeyValueSorter<key_type, mapped_type, RAJA::seq_exec> new_map{
+                 static_cast<size_t>(max_size)};
+
+              if (m_size > 0) {
                  // copy existing state into new map
-                 KeyValueSorter<key_type, mapped_type, RAJA::seq_exec> new_map{max_size};
                  auto & map = m_map;
+
                  CARE_SEQUENTIAL_LOOP(i, 0, m_size) {
                     new_map.setKey(i, map.key(i));
                     new_map.setValue(i, map.value(i));
                  } CARE_SEQUENTIAL_LOOP_END
-                 m_map = std::move(new_map);
               }
-              m_max_size = max_size;
+
+              m_map = std::move(new_map);
            }
+
+           m_max_size = max_size;
         }
 
       private:


### PR DESCRIPTION
* Fix unexpected behavior in care::sort_uniq (a case where the input array should not be modified)
* Fixes care::host_device_map::reserve in the force_keyvaluesorter specialization
* Removes unused variable