### PR TITLE
Miscellaneous bug fixes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,11 +19,15 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 
 ### Changed
 - Changed RAJA reduce policy for CUDA to RAJA::cuda\_reduce\_atomic.
+- Rearranged template parameters of care::sortKeyValueArrays (used by care::KeyValueSorter) for ease of use
 
 ### Fixed
 - Only enable calls to cub::DeviceMergeSort when it is available (used by care::sortArray and care::KeyValueSorter when the type is not arithmetic)
 - Fixes inputs to [hip]cub::DeviceMergeSort::StableSortKeys (used by care::sortArray when the type is not arithmetic)
 - Avoids hardcoding one overload of care::sortArray to use [hip]cub::DeviceRadixSort
+- Fixes a case where care::sort\_uniq should not modify the input array
+- Miscellaneous fixes for care::host\_device\_map
+- Clarified documentation for care::BinarySearch
 
 ### Removed
 - Removed dead ENABLE\_PICK option (corresponding option has been removed from CHAI)

--- a/src/care/KeyValueSorter_decl.h
+++ b/src/care/KeyValueSorter_decl.h
@@ -40,6 +40,7 @@ using LocalKeyValueSorter = KeyValueSorter<KeyType, ValueType, Exec> ;
 
 
 #if defined(CARE_PARALLEL_DEVICE) || CARE_ENABLE_GPU_SIMULATION_MODE
+#if !defined(CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS)
 
 ///////////////////////////////////////////////////////////////////////////
 /// @author Peter Robinson, Alan Dayton
@@ -55,7 +56,7 @@ using LocalKeyValueSorter = KeyValueSorter<KeyType, ValueType, Exec> ;
 ///                             have bugs!
 /// @return void
 ///////////////////////////////////////////////////////////////////////////
-template <typename KeyT, typename ValueT, typename Exec=RAJADeviceExec>
+template <typename Exec, typename KeyT, typename ValueT>
 std::enable_if_t<std::is_arithmetic<typename CHAIDataGetter<KeyT, RAJADeviceExec>::raw_type>::value, void>
 sortKeyValueArrays(host_device_ptr<KeyT> & keys,
                    host_device_ptr<ValueT> & values,
@@ -63,13 +64,14 @@ sortKeyValueArrays(host_device_ptr<KeyT> & keys,
                    const bool noCopy=false);
 
 #if defined(__HIPCC__) || (defined(__CUDACC__) && defined(CUB_MAJOR_VERSION) && defined(CUB_MINOR_VERSION) && (CUB_MAJOR_VERSION >= 2 || (CUB_MAJOR_VERSION == 1 && CUB_MINOR_VERSION >= 14)))
-template <typename KeyT, typename ValueT, typename Exec=RAJADeviceExec>
+template <typename Exec, typename KeyT, typename ValueT>
 std::enable_if_t<!std::is_arithmetic<typename CHAIDataGetter<KeyT, RAJADeviceExec>::raw_type>::value, void>
 sortKeyValueArrays(host_device_ptr<KeyT> & keys,
                    host_device_ptr<ValueT> & values,
                    const size_t start, const size_t len,
                    const bool noCopy=false);
 #endif
+#endif   // !defined(CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS)
 
 ///////////////////////////////////////////////////////////////////////////
 /// @author Benjamin Liu after Alan Dayton
@@ -368,7 +370,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// TODO: add bounds checking
       ///////////////////////////////////////////////////////////////////////////
       void sort(const size_t start, const size_t len) {
-         sortKeyValueArrays<ValueType, KeyType, RAJADeviceExec>(m_values, m_keys, start, len, false);
+         sortKeyValueArrays<RAJADeviceExec>(m_values, m_keys, start, len, false);
       }
 
       ///////////////////////////////////////////////////////////////////////////
@@ -387,7 +389,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// @return void
       ///////////////////////////////////////////////////////////////////////////
       void sort() {
-         sortKeyValueArrays<ValueType, KeyType, RAJADeviceExec>(m_values, m_keys, 0, m_len, true);
+         sortKeyValueArrays<RAJADeviceExec>(m_values, m_keys, 0, m_len, true);
       }
 
       ///////////////////////////////////////////////////////////////////////////
@@ -399,7 +401,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// TODO: add bounds checking
       ///////////////////////////////////////////////////////////////////////////
       void sortByKey(const size_t start, const size_t len) {
-         sortKeyValueArrays<KeyType, ValueType, RAJADeviceExec>(m_keys, m_values, start, len, false);
+         sortKeyValueArrays<RAJADeviceExec>(m_keys, m_values, start, len, false);
       }
 
       ///////////////////////////////////////////////////////////////////////////
@@ -418,7 +420,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// @return void
       ///////////////////////////////////////////////////////////////////////////
       void sortByKey() {
-         sortKeyValueArrays(m_keys, m_values, 0, m_len, true);
+         sortKeyValueArrays<RAJADeviceExec>(m_keys, m_values, 0, m_len, true);
       }
 
       ///////////////////////////////////////////////////////////////////////////
@@ -431,7 +433,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// TODO: add bounds checking
       ///////////////////////////////////////////////////////////////////////////
       void stableSort(const size_t start, const size_t len) {
-         sortKeyValueArrays(m_values, m_keys, start, len, false);
+         sortKeyValueArrays<RAJADeviceExec>(m_values, m_keys, start, len, false);
       }
 
       ///////////////////////////////////////////////////////////////////////////
@@ -451,7 +453,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// TODO: investigate whether radix device sort is a stable sort
       ///////////////////////////////////////////////////////////////////////////
       void stableSort() {
-         sortKeyValueArrays(m_values, m_keys, 0, m_len, true);
+         sortKeyValueArrays<RAJADeviceExec>(m_values, m_keys, 0, m_len, true);
       }
 
       ///////////////////////////////////////////////////////////////////////////

--- a/src/care/KeyValueSorter_impl.h
+++ b/src/care/KeyValueSorter_impl.h
@@ -39,6 +39,7 @@ namespace care {
 
 // TODO openMP parallel implementation
 #if defined(CARE_PARALLEL_DEVICE) || CARE_ENABLE_GPU_SIMULATION_MODE
+#if !defined(CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS)
 
 // TODO: Use if constexpr and std::is_arithmetic_v when c++17 support is required
 
@@ -56,7 +57,7 @@ namespace care {
 ///                             have bugs!
 /// @return void
 ///////////////////////////////////////////////////////////////////////////
-template <typename KeyT, typename ValueT, typename Exec>
+template <typename Exec, typename KeyT, typename ValueT>
 CARE_INLINE
 std::enable_if_t<std::is_arithmetic<typename CHAIDataGetter<KeyT, RAJADeviceExec>::raw_type>::value, void>
 sortKeyValueArrays(host_device_ptr<KeyT> & keys,
@@ -204,7 +205,7 @@ sortKeyValueArrays(host_device_ptr<KeyT> & keys,
 ///                             have bugs!
 /// @return void
 ///////////////////////////////////////////////////////////////////////////
-template <typename KeyT, typename ValueT, typename Exec>
+template <typename Exec, typename KeyT, typename ValueT>
 CARE_INLINE
 std::enable_if_t<!std::is_arithmetic<typename CHAIDataGetter<KeyT, RAJADeviceExec>::raw_type>::value, void>
 sortKeyValueArrays(host_device_ptr<KeyT> & keys,
@@ -327,7 +328,9 @@ sortKeyValueArrays(host_device_ptr<KeyT> & keys,
 #endif // defined(CARE_GPUCC)
 
 }
+
 #endif
+#endif   // !defined(CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS)
 
 ///////////////////////////////////////////////////////////////////////////
 /// @author Benjamin Liu after Alan Dayton
@@ -343,6 +346,9 @@ CARE_INLINE void setKeyValueArraysFromArray(host_device_ptr<KeyType> & keys,
                                             host_device_ptr<ValueType> & values,
                                             const size_t len, const ValueType* arr)
 {
+   // TODO: this requires key types to be constructable from an int -
+   // maybe only enable this for integral types?
+
    CARE_SEQUENTIAL_LOOP(i, 0, len) {
       keys[i] = (KeyType)i;
       values[i] = arr[i];
@@ -501,6 +507,9 @@ template <typename KeyType, typename ValueType>
 CARE_INLINE void setKeyValueArraysFromArray(host_device_ptr<_kv<KeyType,ValueType>> & keyValues,
                                             const size_t len, const ValueType* arr)
 {
+   // TODO: this requires key types to be constructable from an int -
+   // maybe only enable this for integral types?
+
    CARE_SEQUENTIAL_LOOP(i, 0, (int) len) {
       keyValues[i].key = (KeyType)i;
       keyValues[i].value = arr[i];

--- a/src/care/KeyValueSorter_impl.h
+++ b/src/care/KeyValueSorter_impl.h
@@ -346,7 +346,7 @@ CARE_INLINE void setKeyValueArraysFromArray(host_device_ptr<KeyType> & keys,
                                             host_device_ptr<ValueType> & values,
                                             const size_t len, const ValueType* arr)
 {
-   // TODO: this requires key types to be constructable from an int -
+   // TODO: this requires key types to be constructable from size_t -
    // maybe only enable this for integral types?
 
    CARE_SEQUENTIAL_LOOP(i, 0, len) {
@@ -507,7 +507,7 @@ template <typename KeyType, typename ValueType>
 CARE_INLINE void setKeyValueArraysFromArray(host_device_ptr<_kv<KeyType,ValueType>> & keyValues,
                                             const size_t len, const ValueType* arr)
 {
-   // TODO: this requires key types to be constructable from an int -
+   // TODO: this requires key types to be constructable from a size_t -
    // maybe only enable this for integral types?
 
    CARE_SEQUENTIAL_LOOP(i, 0, (int) len) {

--- a/src/care/KeyValueSorter_inst.h
+++ b/src/care/KeyValueSorter_inst.h
@@ -49,7 +49,9 @@ namespace care {
    CARE_EXTERN template CARE_DLL_API void setKeyValueArraysFromArray(host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE> &, const size_t, const CARE_TEMPLATE_ARRAY_TYPE*);
    CARE_EXTERN template CARE_DLL_API void setKeyValueArraysFromManagedArray(host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE> &, const size_t, const host_device_ptr<const CARE_TEMPLATE_ARRAY_TYPE>&);
    CARE_EXTERN template CARE_DLL_API size_t eliminateKeyValueDuplicates(host_device_ptr<CARE_TEMPLATE_KEY_TYPE>&, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE>&, const host_device_ptr<const CARE_TEMPLATE_KEY_TYPE>&, const host_device_ptr<const CARE_TEMPLATE_ARRAY_TYPE>&, const size_t);
+#if !defined(CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS)
    CARE_EXTERN template CARE_DLL_API void sortKeyValueArrays<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJADeviceExec>(host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE> &, const size_t, const size_t, const bool);
+#endif
 
    CARE_EXTERN template class CARE_DLL_API KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJADeviceExec>;
 

--- a/src/care/algorithm_impl.h
+++ b/src/care/algorithm_impl.h
@@ -83,7 +83,7 @@ CARE_HOST_DEVICE CARE_INLINE bool checkSorted(const T* array, const int len,
 
       if (failed) {
          if (warnOnFailure) {
-            printf( "care:%s: %s not in ascending order at index %d", name, argname, last + 1);
+            printf("care:%s: %s not in ascending order at index %d\n", name, argname, last + 1);
          }
          return false;
       }
@@ -433,7 +433,8 @@ CARE_INLINE void IntersectArrays(RAJA::seq_exec exec,
  *
  *             If returnUpperBound is set to true, this will return the
  *             index corresponding to the earliest entry that is greater
- *             than num.
+ *             than num. A return value of -1 indicates that all values
+ *             in map are smaller than or equal to num.
  *
  *             @NOTE: Intentionally implemented this using only the '<'
  *             operator to follow weak strict ordering semantics.

--- a/src/care/host_device_map.h
+++ b/src/care/host_device_map.h
@@ -221,7 +221,7 @@ namespace care {
          CARE_HOST_DEVICE host_device_map() noexcept {};
          
          // constructor taking max_entries
-         host_device_map(size_t max_entries) : m_max_size(max_entries), m_signal(0), m_gpu_map{max_entries}   {
+         host_device_map(size_t max_entries) : m_max_size(max_entries), m_signal{}, m_gpu_map{max_entries}   {
             // m_size_ptr[0] will be atomically incremented as elements are emplaced into the map
             m_size_ptr = int_ptr(1, "map_size");
             // set size to 0
@@ -373,7 +373,7 @@ namespace care {
          int m_size = 0;
          int m_max_size = 0;
          mapped_type m_signal {};
-         KeyValueSorter<key_type, mapped_type, RAJADeviceExec> m_gpu_map{0};
+         KeyValueSorter<key_type, mapped_type, RAJADeviceExec> m_gpu_map{};
    };
 
 #endif // defined(CARE_PARALLEL_DEVICE) || CARE_ENABLE_GPU_SIMULATION_MODE


### PR DESCRIPTION
* Rearrange template parameters for care::sortKeyValueArrays (used by care::KeyValueSorter) for ease of use
* Add a mechanism for preventing explicit instantiations of care::sortKeyValueArrays
* Add note about being able to construct keys from integral types
* Add missing newline to output message
* Use default initialization in host_device_map

Thanks @robinson96 for the fixes!