### PR TITLE
Fix care::IntersectKeyValueSorters

### DIFF
--- a/src/care/KeyValueSorter_decl.h
+++ b/src/care/KeyValueSorter_decl.h
@@ -1193,11 +1193,12 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> {
 #endif // !CARE_ENABLE_GPU_SIMULATION_MODE
 
 
+// Return the keys for each KVS where their values are the same
 #ifdef CARE_PARALLEL_DEVICE
 template <typename KeyType, typename ValueType>
 void IntersectKeyValueSorters(RAJADeviceExec exec, KeyValueSorter<KeyType, ValueType, RAJADeviceExec> sorter1, int size1,
                               KeyValueSorter<KeyType, ValueType, RAJADeviceExec> sorter2, int size2,
-                              host_device_ptr<int> &matches1, host_device_ptr<int>& matches2,
+                              host_device_ptr<KeyType> &matches1, host_device_ptr<KeyType>& matches2,
                               int & numMatches) ;
 #endif // defined(CARE_PARALLEL_DEVICE)
 
@@ -1209,7 +1210,7 @@ template <typename KeyType, typename ValueType>
 void IntersectKeyValueSorters(RAJA::seq_exec exec, 
                               KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> sorter1, int size1,
                               KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> sorter2, int size2,
-                              host_device_ptr<int> &matches1, host_device_ptr<int>& matches2, int & numMatches) ;
+                              host_device_ptr<KeyType> &matches1, host_device_ptr<KeyType>& matches2, int & numMatches) ;
 
 } // namespace care
 

--- a/src/care/KeyValueSorter_impl.h
+++ b/src/care/KeyValueSorter_impl.h
@@ -369,6 +369,9 @@ CARE_INLINE void setKeyValueArraysFromManagedArray(host_device_ptr<KeyType> & ke
                                                    host_device_ptr<ValueType> & values,
                                                    const size_t len, const host_device_ptr<const ValueType>& arr)
 {
+   // TODO: this requires key types to be constructable from size_t -
+   // maybe only enable this for integral types?
+
    FUSIBLE_LOOP_STREAM(i, 0, len) {
       keys[i] = (KeyType) i;
       values[i] = arr[i];
@@ -414,8 +417,8 @@ template <typename KeyType, typename ValueType>
 CARE_INLINE void IntersectKeyValueSorters(RAJADeviceExec exec,
                                           KeyValueSorter<KeyType, ValueType, RAJADeviceExec> sorter1, int size1,
                                           KeyValueSorter<KeyType, ValueType, RAJADeviceExec> sorter2, int size2,
-                                          host_device_ptr<int> &matches1,
-                                          host_device_ptr<int>& matches2,
+                                          host_device_ptr<KeyType>& matches1,
+                                          host_device_ptr<KeyType>& matches2,
                                           int & numMatches)
 {
    int smaller = (size1 < size2) ? size1 : size2 ;
@@ -435,7 +438,7 @@ CARE_INLINE void IntersectKeyValueSorters(RAJADeviceExec exec,
       matches2.namePointer("matches2");
    }
 
-   host_device_ptr<int> smallerMatches, largerMatches;
+   host_device_ptr<KeyType> smallerMatches, largerMatches;
    host_device_ptr<KeyType> smallerKeys, largerKeys;
    int larger, smallStart, largeStart;
    host_device_ptr<const ValueType> smallerArray, largerArray;
@@ -528,6 +531,9 @@ template <typename KeyType, typename ValueType>
 CARE_INLINE void setKeyValueArraysFromManagedArray(host_device_ptr<_kv<KeyType, ValueType> > & keyValues,
                                                    const size_t len, const host_device_ptr<const ValueType>& arr)
 {
+   // TODO: this requires key types to be constructable from a size_t -
+   // maybe only enable this for integral types?
+
    FUSIBLE_LOOP_STREAM(i, 0, (int)len) {
       keyValues[i].key = (KeyType)i;
       keyValues[i].value = arr[i];
@@ -645,14 +651,15 @@ CARE_INLINE void initializeValueArray(host_device_ptr<ValueType>& values,
 #if !CARE_ENABLE_GPU_SIMULATION_MODE
 // This assumes arrays have been sorted and unique. If they are not uniqued the GPU
 // and CPU versions may have different behaviors (the index they match to may be different,
-// with the GPU implementation matching whatever binary search happens to land on, and the// CPU version matching the first instance.
+// with the GPU implementation matching whatever binary search happens to land on, and the
+// CPU version matching the first instance.
 
 template <typename KeyType, typename ValueType>
 CARE_INLINE void IntersectKeyValueSorters(RAJA::seq_exec /* exec */,
                                           KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> sorter1, int size1,
                                           KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> sorter2, int size2,
-                                          host_device_ptr<int> &matches1,
-                                          host_device_ptr<int>& matches2,
+                                          host_device_ptr<KeyType>& matches1,
+                                          host_device_ptr<KeyType>& matches2,
                                           int & numMatches)
 {
    numMatches = 0 ;
@@ -675,8 +682,8 @@ CARE_INLINE void IntersectKeyValueSorters(RAJA::seq_exec /* exec */,
 
    int i = 0 ;
    int j = 0 ;
-   host_ptr<int> host_matches1 = matches1 ;
-   host_ptr<int> host_matches2 = matches2 ;
+   host_ptr<KeyType> host_matches1 = matches1 ;
+   host_ptr<KeyType> host_matches2 = matches2 ;
    /* keys() and values() will allocate managed arrays for the keys and values,
     * respectively, if they were not previously allocated.
     * Check to see whether they were previously allocated. */

--- a/src/care/KeyValueSorter_inst.h
+++ b/src/care/KeyValueSorter_inst.h
@@ -41,7 +41,7 @@ namespace care {
 #if !CARE_ENABLE_GPU_SIMULATION_MODE
    CARE_EXTERN template class CARE_DLL_API KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJA::seq_exec>;
 
-   CARE_EXTERN template CARE_DLL_API void IntersectKeyValueSorters(RAJA::seq_exec, KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJA::seq_exec>, int, KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJA::seq_exec>, int, host_device_ptr<int> &, host_device_ptr<int>&, int &);
+   CARE_EXTERN template CARE_DLL_API void IntersectKeyValueSorters(RAJA::seq_exec, KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJA::seq_exec>, int, KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJA::seq_exec>, int, host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, int &);
 #endif // !CARE_ENABLE_GPU_SIMULATION_MODE
 
 #if defined(CARE_PARALLEL_DEVICE) || CARE_ENABLE_GPU_SIMULATION_MODE
@@ -50,12 +50,12 @@ namespace care {
    CARE_EXTERN template CARE_DLL_API void setKeyValueArraysFromManagedArray(host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE> &, const size_t, const host_device_ptr<const CARE_TEMPLATE_ARRAY_TYPE>&);
    CARE_EXTERN template CARE_DLL_API size_t eliminateKeyValueDuplicates(host_device_ptr<CARE_TEMPLATE_KEY_TYPE>&, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE>&, const host_device_ptr<const CARE_TEMPLATE_KEY_TYPE>&, const host_device_ptr<const CARE_TEMPLATE_ARRAY_TYPE>&, const size_t);
 #if !defined(CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS)
-   CARE_EXTERN template CARE_DLL_API void sortKeyValueArrays<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJADeviceExec>(host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE> &, const size_t, const size_t, const bool);
+   CARE_EXTERN template CARE_DLL_API void sortKeyValueArrays<RAJADeviceExec, CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE>(host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE> &, const size_t, const size_t, const bool);
 #endif
 
    CARE_EXTERN template class CARE_DLL_API KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJADeviceExec>;
 
-   CARE_EXTERN template CARE_DLL_API void IntersectKeyValueSorters(RAJADeviceExec, KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJADeviceExec>, int, KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJADeviceExec>, int, host_device_ptr<int> &, host_device_ptr<int>&, int &);
+   CARE_EXTERN template CARE_DLL_API void IntersectKeyValueSorters(RAJADeviceExec, KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJADeviceExec>, int, KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJADeviceExec>, int, host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, int &);
 
 #endif // defined(CARE_PARALLEL_DEVICE) || CARE_ENABLE_GPU_SIMULATION_MODE
 


### PR DESCRIPTION
* Fix a bug in care::IntersectKeyValueSorters where some parameters were incorrectly hardcoded with a template parameter of int

* Fix explicit instantiation of care::sortKeyValueArrays