### PR TITLE
Fixes for building as a shared library on Windows

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 - Fixes a case where care::sort\_uniq should not modify the input array
 - Miscellaneous fixes for care::host\_device\_map
 - Clarified documentation for care::BinarySearch
+- Added missing attributes to functions for building as a shared library on Windows
 
 ### Removed
 - Removed dead ENABLE\_PICK option (corresponding option has been removed from CHAI)

--- a/src/care/DebugPlugin.h
+++ b/src/care/DebugPlugin.h
@@ -8,6 +8,7 @@
 #ifndef _CARE_DebugPlugin_H_
 #define _CARE_DebugPlugin_H_
 
+#include "care/config.h"
 #include "RAJA/util/PluginStrategy.hpp"
 #include "chai/ExecutionSpaces.hpp"
 
@@ -18,7 +19,7 @@ namespace care{
       public:
          DebugPlugin() = default;
 
-         static void registerPlugin();
+         CARE_DLL_API static void registerPlugin();
 						
          void preLaunch(const RAJA::util::PluginContext& p) override;
 

--- a/src/care/ExecutionSpace.h
+++ b/src/care/ExecutionSpace.h
@@ -31,19 +31,18 @@ namespace care {
    // CHAI and CARE are configured.
    extern CARE_DLL_API care::ExecutionSpace DEFAULT;
 } // namespace care
+
 namespace chai {
-   
    // the ZERO_COPY memory space. Typically PINNED memory, but may be a different space depending on
    // how CHAI and CARE are configured.
-   extern chai::ExecutionSpace ZERO_COPY;
+   extern CARE_DLL_API chai::ExecutionSpace ZERO_COPY;
    // the  PAGEABLE memory space. Typically UM, but may be a different space depending on how
    // CHAI and CARE are configured.
-   extern chai::ExecutionSpace PAGEABLE;
+   extern CARE_DLL_API chai::ExecutionSpace PAGEABLE;
    // the  DEFAULT memory space. Typically GPU for GPU platforms and CPU for CPU platforms, but may be a different space depending on how
    // CHAI and CARE are configured.
-   extern chai::ExecutionSpace DEFAULT;
-
-}
+   extern CARE_DLL_API chai::ExecutionSpace DEFAULT;
+} // namespace chai
 
 #endif // !defined(_CARE_EXECUTION_SPACE_H_)
 

--- a/src/care/ProfilePlugin.h
+++ b/src/care/ProfilePlugin.h
@@ -8,6 +8,7 @@
 #ifndef _CARE_ProfilePlugin_H_
 #define _CARE_ProfilePlugin_H_
 
+#include "care/config.h"
 #include "RAJA/util/PluginStrategy.hpp"
 
 namespace care{
@@ -17,7 +18,7 @@ namespace care{
       public:
          ProfilePlugin() = default;
 
-         static void registerPlugin();
+         CARE_DLL_API static void registerPlugin();
 						
          void preLaunch(const RAJA::util::PluginContext& p) override;
 


### PR DESCRIPTION
* Adds missing attributes to some functions so they are exported when building CARE as a shared library on Windows