### PR TITLE
Remove unused macro

### DIFF
--- a/src/care/KeyValueSorter_decl.h
+++ b/src/care/KeyValueSorter_decl.h
@@ -40,7 +40,6 @@ using LocalKeyValueSorter = KeyValueSorter<KeyType, ValueType, Exec> ;
 
 
 #if defined(CARE_PARALLEL_DEVICE) || CARE_ENABLE_GPU_SIMULATION_MODE
-#if !defined(CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS)
 
 ///////////////////////////////////////////////////////////////////////////
 /// @author Peter Robinson, Alan Dayton
@@ -71,7 +70,6 @@ sortKeyValueArrays(host_device_ptr<KeyT> & keys,
                    const size_t start, const size_t len,
                    const bool noCopy=false);
 #endif
-#endif   // !defined(CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS)
 
 ///////////////////////////////////////////////////////////////////////////
 /// @author Benjamin Liu after Alan Dayton

--- a/src/care/KeyValueSorter_impl.h
+++ b/src/care/KeyValueSorter_impl.h
@@ -39,7 +39,6 @@ namespace care {
 
 // TODO openMP parallel implementation
 #if defined(CARE_PARALLEL_DEVICE) || CARE_ENABLE_GPU_SIMULATION_MODE
-#if !defined(CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS)
 
 // TODO: Use if constexpr and std::is_arithmetic_v when c++17 support is required
 
@@ -330,7 +329,6 @@ sortKeyValueArrays(host_device_ptr<KeyT> & keys,
 }
 
 #endif
-#endif   // !defined(CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS)
 
 ///////////////////////////////////////////////////////////////////////////
 /// @author Benjamin Liu after Alan Dayton

--- a/src/care/KeyValueSorter_inst.h
+++ b/src/care/KeyValueSorter_inst.h
@@ -49,9 +49,7 @@ namespace care {
    CARE_EXTERN template CARE_DLL_API void setKeyValueArraysFromArray(host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE> &, const size_t, const CARE_TEMPLATE_ARRAY_TYPE*);
    CARE_EXTERN template CARE_DLL_API void setKeyValueArraysFromManagedArray(host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE> &, const size_t, const host_device_ptr<const CARE_TEMPLATE_ARRAY_TYPE>&);
    CARE_EXTERN template CARE_DLL_API size_t eliminateKeyValueDuplicates(host_device_ptr<CARE_TEMPLATE_KEY_TYPE>&, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE>&, const host_device_ptr<const CARE_TEMPLATE_KEY_TYPE>&, const host_device_ptr<const CARE_TEMPLATE_ARRAY_TYPE>&, const size_t);
-#if !defined(CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS)
    CARE_EXTERN template CARE_DLL_API void sortKeyValueArrays<RAJADeviceExec, CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE>(host_device_ptr<CARE_TEMPLATE_KEY_TYPE> &, host_device_ptr<CARE_TEMPLATE_ARRAY_TYPE> &, const size_t, const size_t, const bool);
-#endif
 
    CARE_EXTERN template class CARE_DLL_API KeyValueSorter<CARE_TEMPLATE_KEY_TYPE, CARE_TEMPLATE_ARRAY_TYPE, RAJADeviceExec>;
 


### PR DESCRIPTION
Remove CARE_SKIP_SORT_KEY_VALUE_ARRAYS_INSTANTIATIONS macro since it is no longer used.