### PR TITLE
Remove explicit template arguments inside class declarations

### DIFF
--- a/src/care/KeyValueSorter_decl.h
+++ b/src/care/KeyValueSorter_decl.h
@@ -140,7 +140,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// @param[in] len - The number of elements to allocate space for
       /// @return a KeyValueSorter instance
       ///////////////////////////////////////////////////////////////////////////
-      explicit KeyValueSorter<KeyType, ValueType, RAJADeviceExec>(const size_t len)
+      explicit KeyValueSorter(const size_t len)
       : m_len(len)
       , m_ownsPointers(true)
       , m_keys(len, "m_keys")
@@ -157,7 +157,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// @param[in] arr - The raw array to copy elements from
       /// @return a KeyValueSorter instance
       ///////////////////////////////////////////////////////////////////////////
-      KeyValueSorter<KeyType, ValueType, RAJADeviceExec>(const size_t len, const ValueType* arr)
+      KeyValueSorter(const size_t len, const ValueType* arr)
       : m_len(len)
       , m_ownsPointers(true)
       , m_keys(len, "m_keys")
@@ -175,7 +175,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// @param[in] arr - The managed array to copy elements from
       /// @return a KeyValueSorter instance
       ///////////////////////////////////////////////////////////////////////////
-      KeyValueSorter<KeyType, ValueType, RAJADeviceExec>(const size_t len, const host_device_ptr<const ValueType> & arr)
+      KeyValueSorter(const size_t len, const host_device_ptr<const ValueType> & arr)
       : m_len(len)
       , m_ownsPointers(true)
       , m_keys(len, "m_keys")
@@ -194,7 +194,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// @param[in] other - The other KeyValueSorter to copy from
       /// @return a KeyValueSorter instance
       ///////////////////////////////////////////////////////////////////////////
-      CARE_HOST_DEVICE KeyValueSorter<KeyType, ValueType, RAJADeviceExec>(const KeyValueSorter<KeyType, ValueType, RAJADeviceExec> &other)
+      CARE_HOST_DEVICE KeyValueSorter(const KeyValueSorter& other)
       : m_len(other.m_len)
       , m_ownsPointers(false)
       , m_keys(other.m_keys)
@@ -207,7 +207,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// @brief Destructor
       /// Frees the underlying memory if this is the owner.
       ///////////////////////////////////////////////////////////////////////////
-      CARE_HOST_DEVICE ~KeyValueSorter<KeyType, ValueType, RAJADeviceExec>()
+      CARE_HOST_DEVICE ~KeyValueSorter()
       {
 #ifndef CARE_DEVICE_COMPILE
          /// Only attempt to free if we are on the CPU
@@ -223,7 +223,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// @param[in] other - The other KeyValueSorter to copy from
       /// @return *this
       ///////////////////////////////////////////////////////////////////////////
-      KeyValueSorter<KeyType, ValueType, RAJADeviceExec> & operator=(KeyValueSorter<KeyType, ValueType, RAJADeviceExec> & other)
+      KeyValueSorter& operator=(KeyValueSorter& other)
       {
          if (this != &other) {
             free();
@@ -245,7 +245,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
       /// @param[in] other - The other KeyValueSorter to move from
       /// @return *this
       ///////////////////////////////////////////////////////////////////////////
-      KeyValueSorter<KeyType, ValueType, RAJADeviceExec> & operator=(KeyValueSorter<KeyType, ValueType, RAJADeviceExec> && other)
+      KeyValueSorter& operator=(KeyValueSorter&& other)
       {
          if (this != &other) {
             free();
@@ -687,7 +687,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> {
       /// @brief Default constructor
       /// @return a KeyValueSorter instance
       ///////////////////////////////////////////////////////////////////////////
-      KeyValueSorter<KeyType, ValueType, RAJA::seq_exec>() {}
+      KeyValueSorter() {}
 
       ///////////////////////////////////////////////////////////////////////////
       /// @author Peter Robinson, Alan Dayton
@@ -696,7 +696,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> {
       /// @param[in] len - The number of elements to allocate space for
       /// @return a KeyValueSorter instance
       ///////////////////////////////////////////////////////////////////////////
-      explicit KeyValueSorter<KeyType, ValueType, RAJA::seq_exec>(size_t len)
+      explicit KeyValueSorter(size_t len)
       : m_len(len)
       , m_ownsPointers(true)
       , m_keys(nullptr)
@@ -714,7 +714,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> {
       /// @param[in] arr - The raw array to copy elements from
       /// @return a KeyValueSorter instance
       ///////////////////////////////////////////////////////////////////////////
-      KeyValueSorter<KeyType, ValueType, RAJA::seq_exec>(const size_t len, const ValueType* arr)
+      KeyValueSorter(const size_t len, const ValueType* arr)
       : m_len(len)
       , m_ownsPointers(true)
       , m_keys(nullptr)
@@ -733,7 +733,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> {
       /// @param[in] arr - The managed array to copy elements from
       /// @return a KeyValueSorter instance
       ///////////////////////////////////////////////////////////////////////////
-      KeyValueSorter<KeyType, ValueType, RAJA::seq_exec>(const size_t len, const host_device_ptr<const ValueType> & arr)
+      KeyValueSorter(const size_t len, const host_device_ptr<const ValueType> & arr)
       : m_len(len)
       , m_ownsPointers(true)
       , m_keys(nullptr)
@@ -753,7 +753,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> {
       /// @param[in] other - The other KeyValueSorter to copy from
       /// @return a KeyValueSorter instance
       ///////////////////////////////////////////////////////////////////////////
-      CARE_HOST_DEVICE KeyValueSorter<KeyType, ValueType, RAJA::seq_exec>(const KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> &other)
+      CARE_HOST_DEVICE KeyValueSorter(const KeyValueSorter& other)
       : m_len(other.m_len)
       , m_ownsPointers(false)
       , m_keys(other.m_keys)
@@ -767,7 +767,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> {
       /// @brief Destructor
       /// Frees the underlying memory if this is the owner.
       ///////////////////////////////////////////////////////////////////////////
-      CARE_HOST_DEVICE ~KeyValueSorter<KeyType, ValueType, RAJA::seq_exec>()
+      CARE_HOST_DEVICE ~KeyValueSorter()
       {
 #ifndef CARE_DEVICE_COMPILE
          free();
@@ -782,7 +782,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> {
       /// @param[in] other - The other KeyValueSorter to copy from
       /// @return *this
       ///////////////////////////////////////////////////////////////////////////
-      KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> & operator=(KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> & other)
+      KeyValueSorter& operator=(KeyValueSorter& other)
       {
          if (this != &other) {
             free();
@@ -805,7 +805,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> {
       /// @param[in] other - The other KeyValueSorter to move from
       /// @return *this
       ///////////////////////////////////////////////////////////////////////////
-      KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> & operator=(KeyValueSorter<KeyType, ValueType, RAJA::seq_exec> && other)
+      KeyValueSorter& operator=(KeyValueSorter&& other)
       {
          if (this != &other) {
             free();

--- a/src/care/host_device_map.h
+++ b/src/care/host_device_map.h
@@ -48,7 +48,7 @@ namespace care {
          host_device_map() noexcept;
          host_device_map(host_device_map const & other) noexcept;
          host_device_map(host_device_map && other) noexcept;
-         host_device_map<key_type, mapped_type, Exec>& operator=(host_device_map&& other) noexcept;
+         host_device_map& operator=(host_device_map&& other) noexcept;
          CARE_HOST_DEVICE inline void emplace(key_type key, mapped_type val) const;
          CARE_HOST_DEVICE inline mapped_type at(key_type key) const;
          void sort();
@@ -113,7 +113,8 @@ namespace care {
             other.m_iterator = nullptr;
             other.m_next_iterator_index = nullptr;
          }
-         host_device_map<key_type, mapped_type, RAJA::seq_exec> & operator=(host_device_map && other) noexcept  {
+
+         host_device_map& operator=(host_device_map && other) noexcept  {
             delete m_map;
             delete m_size;
             delete m_iterator;
@@ -255,7 +256,7 @@ namespace care {
          }
 
          // move assignment
-         host_device_map<key_type,mapped_type, RAJADeviceExec> & operator=(host_device_map && other) noexcept {
+         host_device_map& operator=(host_device_map && other) noexcept {
             m_max_size = other.m_max_size;
             m_signal = other.m_signal;
             m_gpu_map = std::move(other.m_gpu_map);
@@ -437,7 +438,7 @@ namespace care {
          }
          
          // move assignment
-         host_device_map<key_type, mapped_type, force_keyvaluesorter>  & operator=(host_device_map && other)  noexcept {
+         host_device_map& operator=(host_device_map && other)  noexcept {
             delete m_size_ptr;
             m_size_ptr = other.m_size_ptr;
             m_size = other.m_size;

--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -88,28 +88,28 @@ namespace care {
       ///
       /// Default constructor
       ///
-      CARE_HOST_DEVICE host_device_ptr<T>() noexcept : MA() {}
+      CARE_HOST_DEVICE host_device_ptr() noexcept : MA() {}
 
       ///
       /// @author Peter Robinson
       ///
       /// nullptr constructor
       ///
-      CARE_HOST_DEVICE host_device_ptr<T>(std::nullptr_t from) noexcept : MA (from) {}
+      CARE_HOST_DEVICE host_device_ptr(std::nullptr_t from) noexcept : MA (from) {}
 
       ///
       /// @author Peter Robinson
       ///
       /// Copy constructor
       ///
-      CARE_HOST_DEVICE host_device_ptr<T>(host_device_ptr<T> const & other) : MA (other) {}
+      CARE_HOST_DEVICE host_device_ptr(host_device_ptr<T> const & other) : MA (other) {}
 
       ///
       /// @author Peter Robinson
       ///
       /// Construct from a chai::ManagedArray
       ///
-      CARE_HOST_DEVICE host_device_ptr<T>(MA const & other) : MA (other) {}
+      CARE_HOST_DEVICE host_device_ptr(MA const & other) : MA (other) {}
 
       ///
       /// @author Peter Robinson
@@ -118,7 +118,7 @@ namespace care {
       ///
       template <bool B = std::is_const<T>::value,
                 typename std::enable_if<B, int>::type = 1>
-      CARE_HOST_DEVICE host_device_ptr<T>(MAU const & other)
+      CARE_HOST_DEVICE host_device_ptr(MAU const & other)
          : MA (other)
       {
       }
@@ -130,14 +130,14 @@ namespace care {
       /// This is defined when the CHAI resource manager is disabled
       ///
 #if defined(CARE_DEEP_COPY_RAW_PTR)
-      host_device_ptr<T>(T* from, size_t size, const char * name)
+      host_device_ptr(T* from, size_t size, const char * name)
          : MA(size)
       {
          std::copy_n(from, size, (T_non_const*)MA::data());
       }
 #else /* defined(CARE_DEEP_COPY_RAW_PTR) */
 #if defined (CHAI_DISABLE_RM) || defined(CHAI_THIN_GPU_ALLOCATE)
-      host_device_ptr<T>(T* from, size_t size, const char * name)
+      host_device_ptr(T* from, size_t size, const char * name)
          : MA(from, nullptr, size, nullptr)
       {
       }
@@ -148,7 +148,7 @@ namespace care {
       /// Construct from a raw pointer, size, and name
       /// This is defined when the CHAI resource manager is enabled
       ///
-      host_device_ptr<T>(T* from, size_t size, const char * name)
+      host_device_ptr(T* from, size_t size, const char * name)
          : MA(size == 0 ? nullptr : from,
               chai::ArrayManager::getInstance(),
               size,
@@ -172,7 +172,7 @@ namespace care {
       ///
       /// Construct from a size and name
       ///
-      host_device_ptr<T>(size_t size, const char * name) : MA (size) {
+      host_device_ptr(size_t size, const char * name) : MA (size) {
          registerCallbacks(name);
       }
 
@@ -182,7 +182,7 @@ namespace care {
       /// Construct from a size, initial value, and name
       /// Optionally inititialize on device rather than the host
       ///
-      CARE_HOST_DEVICE host_device_ptr<T>(size_t size, T initial, const char * name, bool initOnDevice=false) : MA (size) {
+      CARE_HOST_DEVICE host_device_ptr(size_t size, T initial, const char * name, bool initOnDevice=false) : MA (size) {
          registerPointerName(name); 
          initialize(size, initial, 0, initOnDevice);
       }

--- a/src/care/host_ptr.h
+++ b/src/care/host_ptr.h
@@ -72,7 +72,7 @@ namespace care {
          ///
          template <bool B = std::is_const<T>::value,
                    typename std::enable_if<B, int>::type = 1>
-         host_ptr<T>(host_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr.data()) {}
+         host_ptr(host_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr.data()) {}
 
          ///
          /// @author Peter Robinson
@@ -88,7 +88,7 @@ namespace care {
          ///
          template <bool B = std::is_const<T>::value,
                    typename std::enable_if<B, int>::type = 1>
-         host_ptr<T>(chai::ManagedArray<T_non_const> ptr) : m_ptr(ptr.data(chai::CPU)) {}
+         host_ptr(chai::ManagedArray<T_non_const> ptr) : m_ptr(ptr.data(chai::CPU)) {}
 
          ///
          /// Copy assignment operator
@@ -143,7 +143,7 @@ namespace care {
          /// Pointer arithmetic
          ///
          template<typename Idx>
-         host_ptr<T> & operator +=(Idx i) { m_ptr += i; return *this; }
+         host_ptr& operator +=(Idx i) { m_ptr += i; return *this; }
 
          ///
          /// @author Danny Taller

--- a/src/care/local_ptr.h
+++ b/src/care/local_ptr.h
@@ -67,14 +67,14 @@ namespace care {
          ///
          template <bool B = std::is_const<T>::value,
                    typename std::enable_if<B, int>::type = 1>
-         CARE_HOST_DEVICE local_ptr<T>(local_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr.data()) {}
+         CARE_HOST_DEVICE local_ptr(local_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr.data()) {}
 
          ///
          /// @author Peter Robinson
          ///
          /// Construct from host_ptr
          ///
-         CARE_HOST_DEVICE local_ptr<T>(host_ptr<T> const &ptr) noexcept : m_ptr(ptr.data()) {}
+         CARE_HOST_DEVICE local_ptr(host_ptr<T> const &ptr) noexcept : m_ptr(ptr.data()) {}
 
          ///
          /// @author Peter Robinson
@@ -83,14 +83,14 @@ namespace care {
          ///
          template <bool B = std::is_const<T>::value,
                    typename std::enable_if<B, int>::type = 1>
-         CARE_HOST_DEVICE local_ptr<T>(host_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr.cdata()) {}
+         CARE_HOST_DEVICE local_ptr(host_ptr<T_non_const> const &ptr) noexcept : m_ptr(ptr.cdata()) {}
 
          ///
          /// @author Peter Robinson
          ///
          /// Construct from chai::ManagedArray
          ///
-         CARE_HOST_DEVICE local_ptr<T>(chai::ManagedArray<T> const &ptr) : m_ptr(ptr.data()) {}
+         CARE_HOST_DEVICE local_ptr(chai::ManagedArray<T> const &ptr) : m_ptr(ptr.data()) {}
 
          ///
          /// @author Peter Robinson
@@ -99,7 +99,7 @@ namespace care {
          ///
          template <bool B = std::is_const<T>::value,
                    typename std::enable_if<B, int>::type = 1>
-         CARE_HOST_DEVICE local_ptr<T>(chai::ManagedArray<T_non_const> const &ptr) : m_ptr(ptr.data()) {}
+         CARE_HOST_DEVICE local_ptr(chai::ManagedArray<T_non_const> const &ptr) : m_ptr(ptr.data()) {}
 
          ///
          /// Copy assignment operator


### PR DESCRIPTION
Explicitly specifying the template argument in constructors of a template class was unnecessary but allowed until C++20:

```
CARE_HOST_DEVICE host_device_ptr<T>() noexcept : MA() {}
```

The following code should work with C++20 and earlier standards as well:

```
CARE_HOST_DEVICE host_device_ptr() noexcept : MA() {}
```

Fixes #337 