### PR TITLE
Update to nvtx3

### DIFF
--- a/cmake/SetupDependencies.cmake
+++ b/cmake/SetupDependencies.cmake
@@ -121,7 +121,7 @@ endif()
 ################################
 # NVTOOLSEXT
 ################################
-if(ENABLE_CUDA AND NOT TARGET CUDA::nvToolsExt)
+if(ENABLE_CUDA AND NOT CUDAToolkit_FOUND)
    set(CUDAToolkit_ROOT ${CUDA_TOOLKIT_ROOT_DIR})
    find_package(CUDAToolkit)
 endif()

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -27,9 +27,9 @@ Required Dependencies
 
 Optional Dependencies
 =====================
-* Cub (optional)
-* LLNL_GlobalID (optional)
-* NVTX (optional)
+* CUDA
+* Cub
+* LLNL_GlobalID
 
 Contributors
 ============

--- a/host-configs/lc/toss_4_x86_64_ib/nvcc_clang.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/nvcc_clang.cmake
@@ -1,0 +1,32 @@
+##############################################################################
+# Copyright (c) 2020-25, Lawrence Livermore National Security, LLC and CARE
+# project contributors. See the CARE LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
+
+# Use gcc std libraries
+set(GCC_VER "13.3.1" CACHE STRING "")
+set(GCC_DIR "/usr/tce/packages/gcc/gcc-${GCC_VER}-magic" CACHE PATH "")
+
+# Use clang toolchain for host code compilers
+set(CLANG_VER "14.0.6" CACHE STRING "")
+set(CLANG_DIR "/usr/tce/packages/clang/clang-${CLANG_VER}-magic" CACHE PATH "")
+
+set(CMAKE_C_COMPILER "${CLANG_DIR}/bin/clang" CACHE PATH "")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${GCC_DIR}" CACHE STRING "")
+
+set(CMAKE_CXX_COMPILER "${CLANG_DIR}/bin/clang++" CACHE PATH "")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_DIR}" CACHE STRING "")
+
+# Use nvcc as the device code compiler
+set(ENABLE_CUDA ON CACHE BOOL "")
+set(CUDA_VER "12.9.1" CACHE STRING "")
+set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-${CUDA_VER}" CACHE PATH "")
+set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=--gcc-toolchain=${GCC_DIR}" CACHE STRING "")
+set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}" CACHE PATH "")
+set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
+
+# Prevent incorrect implicit libraries from being linked in
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-10.3.1/lib/gcc/x86_64-redhat-linux/10;/usr/tce/packages/gcc/gcc-10.3.1/lib64;/lib64;/usr/lib64;/lib;/usr/lib" CACHE STRING "")

--- a/host-configs/lc/toss_4_x86_64_ib/nvcc_clang.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/nvcc_clang.cmake
@@ -24,7 +24,7 @@ set(ENABLE_CUDA ON CACHE BOOL "")
 set(CUDA_VER "12.9.1" CACHE STRING "")
 set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-${CUDA_VER}" CACHE PATH "")
 set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=--gcc-toolchain=${GCC_DIR}" CACHE STRING "")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=--gcc-toolchain=${GCC_DIR} -Wno-deprecated-gpu-targets -Wno-unused-command-line-argument" CACHE STRING "")
 set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}" CACHE PATH "")
 set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
 

--- a/src/care/CMakeLists.txt
+++ b/src/care/CMakeLists.txt
@@ -99,7 +99,9 @@ if(ENABLE_CUDA)
    # separable compilation, delay all device linking to executable linking time
    # set (CUDA_SEPARABLE_COMPILATION ON BOOL "" )
 
-   if(TARGET CUDA::nvToolsExt)
+   if(TARGET CUDA::nvtx3)
+      list(APPEND care_depends CUDA::nvtx3)
+   elseif(TARGET CUDA::nvToolsExt)
       list(APPEND care_depends CUDA::nvToolsExt)
    endif()
 

--- a/src/care/CMakeLists.txt
+++ b/src/care/CMakeLists.txt
@@ -101,8 +101,6 @@ if(ENABLE_CUDA)
 
    if(TARGET CUDA::nvtx3)
       list(APPEND care_depends CUDA::nvtx3)
-   elseif(TARGET CUDA::nvToolsExt)
-      list(APPEND care_depends CUDA::nvToolsExt)
    endif()
 
    list(APPEND care_depends cub::cub cuda)

--- a/src/care/ProfilePlugin.cpp
+++ b/src/care/ProfilePlugin.cpp
@@ -10,12 +10,7 @@
 
 /* CUDA profiling macros */
 #if defined(__CUDACC__) && CARE_HAVE_NVTOOLSEXT
-// TODO: Use nvtx3 on other platforms besides Windows
-#if defined(_WIN32)
 #include "nvtx3/nvToolsExt.h"
-#else
-#include "nvToolsExt.h"
-#endif
 #endif
 
 namespace care{

--- a/src/care/ProfilePlugin.cpp
+++ b/src/care/ProfilePlugin.cpp
@@ -9,7 +9,7 @@
 #include "care/PluginData.h"
 
 /* CUDA profiling macros */
-#if defined(__CUDACC__) && CARE_HAVE_NVTOOLSEXT
+#if defined(__CUDACC__)
 #include "nvtx3/nvToolsExt.h"
 #endif
 
@@ -33,7 +33,7 @@ namespace care{
    }
 
    void ProfilePlugin::preLaunch(const RAJA::util::PluginContext& p) {
-#if defined(__CUDACC__) && CARE_HAVE_NVTOOLSEXT
+#if defined(__CUDACC__)
       // Profile the host loops
       if (s_profile_host_loops && p.platform == RAJA::Platform::host) {
          std::string name = PluginData::getFileName() + std::to_string(PluginData::getLineNumber());
@@ -50,12 +50,12 @@ namespace care{
          eventAttrib.message.ascii = name.c_str();
          nvtxRangePushEx(&eventAttrib);
       }
-#endif // defined(__CUDACC__) && CARE_HAVE_NVTOOLSEXT
+#endif // defined(__CUDACC__)
    }
 
 
    void ProfilePlugin::postLaunch(const RAJA::util::PluginContext& p) {
-#if defined(__CUDACC__) && CARE_HAVE_NVTOOLSEXT
+#if defined(__CUDACC__)
       if (s_profile_host_loops && p.platform == RAJA::Platform::host) {
          // TODO: Add error checking
          nvtxRangePop();

--- a/src/care/config.h.in
+++ b/src/care/config.h.in
@@ -30,7 +30,6 @@
 
 // Optional dependencies
 #cmakedefine01 CARE_HAVE_LLNL_GLOBALID
-#cmakedefine01 CARE_HAVE_NVTOOLSEXT
 
 #ifdef CARE_ENABLE_EXTERN_INSTANTIATE
 #define CARE_INLINE

--- a/src/care/detail/test_utils.h
+++ b/src/care/detail/test_utils.h
@@ -15,7 +15,7 @@
 
 /* CUDA profiling macros */
 #ifdef __CUDACC__
-#include "nvToolsExt.h"
+#include "nvtx3/nvToolsExt.h"
 #ifdef CARE_TEST_PUSH_VERBOSE
 #define PUSH_PRINT(NAME) printf("%s\n",name);
 #else


### PR DESCRIPTION
Support for nvtx2 has been deprecated for a while and was removed in cuda 12.9. We switch to nvtx3, which has been supported since cuda 10.0.

The CUDA::nvToolsExt CMake target has been deprecated since CMake 3.25, so use the newer CUDA::nvtx3 target if available (added in CMake 3.25).