### PR TITLE
Update RSC (rocm toolchain, mpich, cce), spack and spack-packages

### DIFF
--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase": "initconfig",
 "package_source_dir": "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "v1.0.2",
+"spack_branch": "v1.1.1",
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": ["scripts/radiuss-spack-configs/spack_repo/llnl_radiuss/packages", "scripts/spack_packages/spack_repo/llnl_care/packages"],
 "spack_setup_clingo": false


### PR DESCRIPTION
- [X] Update to rocm 6.4.3 and mpich 8.1.33, then with mpich 9.0.1
- [X] Update to spack 1.1.1 (concretizer perf improvements)
- [X] Update to cce 21
- [X] Add one job with rocm 7.2 and mpich 9.1, keep rocm 6.4.3 for most specs (production state).