### PR TITLE
Algorithm consistency fix for IntersectKeyValueSorters

### DIFF
--- a/src/care/KeyValueSorter_decl.h
+++ b/src/care/KeyValueSorter_decl.h
@@ -1491,9 +1491,7 @@ void IntersectKeyValueSorters(RAJADeviceExec exec, KeyValueSorter<KeyType, Value
                               int & numMatches) ;
 #endif // defined(CARE_PARALLEL_DEVICE)
 
-// This assumes arrays have been sorted and unique. If they are not uniqued the GPU
-// and CPU versions may have different behaviors (the index they match to may be different, 
-// with the GPU implementation matching whatever binary search happens to land on, and the// CPU version matching the first instance. 
+// This assumes arrays have been sorted.
 
 template <typename KeyType, typename ValueType>
 void IntersectKeyValueSorters(RAJA::seq_exec exec, 

--- a/src/care/KeyValueSorter_impl.h
+++ b/src/care/KeyValueSorter_impl.h
@@ -468,7 +468,17 @@ CARE_INLINE void IntersectKeyValueSorters(RAJADeviceExec exec,
    host_device_ptr<int> searches{smaller+1};
    host_device_ptr<int> matched{smaller+1};
    CARE_STREAM_LOOP(i, 0, smaller+1) {
-      searches[i] = i != smaller ? care::BinarySearch<ValueType>(largerArray, largeStart, larger, smallerArray[i+smallStart]) : -1;
+      if (i == smaller) {
+         searches[i] = -1;
+      }
+      else {
+         // to be consistent with CPU algorithm, find the first match
+         int match = care::BinarySearch<ValueType>(largerArray, largeStart, larger, smallerArray[i+smallStart]);
+         while (match > largeStart && largerArray[match-1] == largerArray[match]) {
+            --match;
+         }
+         searches[i] = match;
+      }
       matched[i] = i != smaller && searches[i] > -1;
    } CARE_STREAM_LOOP_END
 


### PR DESCRIPTION
Makes the behavior consistent between the CPU and GPU versions of this algorithm.