### PR TITLE
Bugfix in GPU version of KeyValueSorter::sortByKeyThenValue

### DIFF
--- a/src/care/KeyValueSorter_decl.h
+++ b/src/care/KeyValueSorter_decl.h
@@ -464,7 +464,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
          auto keys = m_keys;
          
          // Use SCAN_LOOP to identify where ranges start
-         SCAN_LOOP(i, start, start+len-1, idx, count,
+         SCAN_LOOP(i, start, start+len, idx, count,
                   (i == start) || (keys[i] != keys[i-1])) {
             rangeStarts[idx] = i;
          } SCAN_LOOP_END(len, idx, count)

--- a/src/care/KeyValueSorter_decl.h
+++ b/src/care/KeyValueSorter_decl.h
@@ -467,7 +467,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
          SCAN_LOOP(i, start, start+len, idx, count,
                   (i == start) || (keys[i] != keys[i-1])) {
             rangeStarts[idx] = i;
-         } SCAN_LOOP_END(len, idx, count)
+         } SCAN_LOOP_END(start+len, idx, count)
 
          // Set the last range end
          rangeStarts.set(count , start+len);
@@ -617,7 +617,7 @@ class CARE_DLL_API KeyValueSorter<KeyType, ValueType, RAJADeviceExec> {
             
             // Use exclusive scan to compute output positions
             host_device_ptr<int> positions(m_len+1);
-            care::exclusive_scan(RAJADeviceExec{}, isUnique, positions, m_len, 0, false);
+            care::exclusive_scan(RAJADeviceExec{}, isUnique, positions, m_len + 1, 0, false);
             
             // Get the total number of unique elements
             int newSize = positions.pick(m_len);


### PR DESCRIPTION
Fixes a fencepost error for exclusive scans.