### PR TITLE
Remove unncessary requirement for using the platform default stream in LoopFuser

### DIFF
--- a/src/care/LoopFuser.cpp
+++ b/src/care/LoopFuser.cpp
@@ -5,9 +5,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////
 
-// Loop Fuser uses the CUDA/HIP default stream and wants to enqueue events in the default stream
-#define CAMP_USE_PLATFORM_DEFAULT_STREAM 1
-
 #include "umpire/Allocator.hpp"
 #include "umpire/TypedAllocator.hpp"
 


### PR DESCRIPTION
* CAMP v2026.07 no longer allows clients to determine the default stream on a translation unit basis due to the ODR violations that almost certainly will occur, such as here in the LoopFuser.
* From a visual inspection, it does not appear that the LoopFuser actually relies on the 0 stream, and in fact, it may be more dangerous for it to use a different stream than the rest of CARE.
* Client testing is underway to validate this change in at least one real application.