### PR TITLE
Fix overload ambiguity errors

### DIFF
--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -21,6 +21,7 @@
 #include "chai/ManagedArray.hpp"
 
 // Std library headers
+#include <concepts>
 #include <cstddef>
 
 
@@ -93,9 +94,16 @@ namespace care {
       ///
       /// @author Peter Robinson
       ///
-      /// nullptr constructor
+      /// Construct from nullptr
       ///
-      CARE_HOST_DEVICE host_device_ptr(std::nullptr_t from) noexcept : MA (from) {}
+      /// @note The constraint prevents overload ambiguity between this
+      ///       constructor and the size_t constructor when constructing
+      ///       with the integer literal 0. Additionally, the constraint
+      ///       is a workaround for a nvcc bug where overload resolution
+      ///       can incorrectly report an ambiguity between this constructor
+      ///       and the size_t constructor.
+      ///
+      CARE_HOST_DEVICE host_device_ptr(std::same_as<std::nullptr_t> auto from) noexcept : MA (from) {}
 
       ///
       /// Construct from a size


### PR DESCRIPTION
`care::host_device_ptr` had two constructors that sometimes led to compilation errors due to ambiguous overload resolution.

```
CARE_HOST_DEVICE host_device_ptr(std::nullptr_t from);
CARE_HOST_DEVICE explicit host_device_ptr(size_t elems);
```

Compilation would fail when constructing a `host_device_ptr` from the integer literal `0` because the compiler can't decide which overload to pick. Additionally, nvcc erroneously reports ambiguity when constructing from an int in certain cases.

Using a constraint resolves the ambiguity in both of those situations. The nullptr constructor will now only accept `nullptr` or a variable of type `std::nullptr_t`. The size_t constructor will get all the rest, including `0`.