### PR TITLE
Avoid macro name conflict

### DIFF
--- a/src/care/detail/test_utils.h
+++ b/src/care/detail/test_utils.h
@@ -56,9 +56,8 @@ static unsigned int currentColor = 0;
 /// @note  Adapted from CHAI
 ///
 /////////////////////////////////////////////////////////////////////////
-#define str(X) #X
 #define GPU_TEST(X, Y) static void cuda_test_ ## X_ ## Y(); \
-   TEST(X, gpu_test_##Y) { PUSH_RANGE(str(Y)); cuda_test_ ## X_ ## Y(); POP_RANGE ;} \
+   TEST(X, gpu_test_##Y) { PUSH_RANGE(CARE_STRINGIFY(Y)); cuda_test_ ## X_ ## Y(); POP_RANGE ;} \
    static void cuda_test_ ## X_ ## Y()
 
 


### PR DESCRIPTION
CARE testing defined a macro named `str`, which surprisingly hasn't conflicted with anything until now. We switch to `CARE_STRINGIFY` since it is already available for use.