### PR TITLE
Add host_device_ptr<T>::slice method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,10 +12,21 @@ in this file.
 
 The format of this file is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] - Release date yyyy-mm-dd
+
+### Added
+- Added `host_device_ptr<T>::slice` function to make passing slices easier to algorithms.
+
+### Changed
+- Inlined many device APIs to reduce the need for relocatable device code, though the LoopFuser still requires it.
+
+### Fixed
+- Fixed macro name conflict in tests.
+
 ## [Version 2026.07.0] - Release date 2026-08-11
 
 ### Added
-- Add ATOMIC\_GENERIC and ATOMIC\_GENERIC\_WITH\_STOP for new generic atomic implementations in RAJA v2026.07.0.
+- Add `ATOMIC_GENERIC` and `ATOMIC_GENERIC_WITH_STOP` for new generic atomic implementations in RAJA v2026.07.0.
 - Added `sortKeyValueArrays` for simultaneously sorting two arrays.
 - Added additional instantiations when configured with explicit template instantiations.
 

--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -211,6 +211,11 @@ namespace care {
          return *reinterpret_cast<host_device_ptr<const T> const *> (this);
       }
 
+      ///
+      /// Copy assignment operator
+      ///
+      host_device_ptr& operator=(const host_device_ptr& other) = default;
+
 #if defined(CARE_ENABLE_BOUNDS_CHECKING)
       template <class Index>
       inline void boundsCheck(const Index i) const {
@@ -230,11 +235,6 @@ namespace care {
          }
       }
 #endif
-
-      ///
-      /// Copy assignment operator
-      ///
-      host_device_ptr& operator=(const host_device_ptr& other) = default;
 
       ///
       /// @author Peter Robinson
@@ -511,6 +511,18 @@ namespace care {
 
       CARE_HOST void move(ExecutionSpace space) {
          MA::move(chai::ExecutionSpace((int) space));
+      }
+
+      ///
+      /// Create a shallow slice of this array.
+      ///
+      /// @param begin The starting element of the slice.
+      /// @param elems The number of elements in the slice.
+      /// @return A host_device_ptr referring to the sliced range.
+      ///
+      CARE_HOST_DEVICE host_device_ptr<T> slice(size_t begin,
+                                                size_t elems = (size_t)-1) const {
+         return host_device_ptr<T>(MA::slice(begin, elems));
       }
    }; // class host_device_ptr
 


### PR DESCRIPTION
* Slicing a `care::host_device_ptr<T>` should return a `care::host_device_ptr<T>`. Previously, the `chai::ManagedArray<T>::slice` function was being called and returning a `chai::ManagedArray<T>`. That made it difficult to pass slices to care algorithms.
* Moved assignment operator right after constructors