### PR TITLE
Add segmented sort

### DIFF
--- a/src/care/CMakeLists.txt
+++ b/src/care/CMakeLists.txt
@@ -60,7 +60,15 @@ set(care_headers
     Setup.h
     single_access_ptr.h
     util.h
- )
+    sort.h
+    )
+
+set(care_host_headers
+    host/sort.h
+    )
+
+set(care_cuda_headers)
+set(care_hip_headers)
 
 set(care_sources
     care.cpp
@@ -97,6 +105,8 @@ if(ENABLE_OPENMP)
 endif()
 
 if(ENABLE_CUDA)
+   list(APPEND care_cuda_headers cuda/sort.h)
+
    # separable compilation, delay all device linking to executable linking time
    # set (CUDA_SEPARABLE_COMPILATION ON BOOL "" )
 
@@ -109,12 +119,17 @@ endif()
 
 
 if(ENABLE_HIP)
+  list(APPEND care_hip_headers hip/sort.h)
+
   list(APPEND care_depends blt::hip)
 endif ()
 
 blt_add_library(NAME care
                 SOURCES    ${care_sources}
                 HEADERS    ${care_headers}
+                           ${care_host_headers}
+                           ${care_cuda_headers}
+                           ${care_hip_headers}
                 INCLUDES   ${care_includes}
                 DEPENDS_ON ${care_depends})
 
@@ -124,6 +139,15 @@ blt_add_library(NAME care
 
 install(FILES       ${care_headers}
         DESTINATION include/care)
+
+install(FILES ${care_host_headers}
+        DESTINATION include/care/host)
+
+install(FILES ${care_cuda_headers}
+        DESTINATION include/care/cuda)
+
+install(FILES ${care_hip_headers}
+        DESTINATION include/care/hip)
 
 install(TARGETS care
         EXPORT  care-targets
@@ -153,4 +177,3 @@ install(
       ${PROJECT_SOURCE_DIR}/cmake/modules/FindCUB.cmake
    DESTINATION
       lib/cmake/care)
-

--- a/src/care/cuda/sort.h
+++ b/src/care/cuda/sort.h
@@ -1,0 +1,72 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lawrence Livermore National Security, LLC and other CARE
+// contributors. See the CARE LICENSE and COPYRIGHT files for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef CARE_CUDA_SORT_H
+#define CARE_CUDA_SORT_H
+
+#include "care/CHAIDataGetter.h"
+#include "care/DefaultMacros.h"
+#include "care/host_device_ptr.h"
+
+#include <cstddef>
+#include <utility>
+
+#include "cub/cub.cuh"
+
+namespace care::cuda {
+
+template <typename KeyT, typename OffsetT>
+CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,
+                                care::host_device_ptr<OffsetT> const& offsets)
+{
+   const size_t numSegments = offsets.size() > 0 ? offsets.size() - 1 : 0;
+   const size_t numItems = keys.size();
+
+   if (numSegments == 0 || numItems == 0) {
+      return;
+   }
+
+   CHAIDataGetter<KeyT, RAJADeviceExec> keyGetter {};
+   auto* rawKeys = keyGetter.getRawArrayData(keys);
+
+   CHAIDataGetter<OffsetT, RAJADeviceExec> offsetGetter {};
+   const auto* rawOffsets = offsetGetter.getConstRawArrayData(offsets);
+
+   care::host_device_ptr<KeyT> result(numItems);
+   auto* rawResult = keyGetter.getRawArrayData(result);
+
+   size_t tempStorageBytes = 0;
+   cub::DeviceSegmentedSort::SortKeys(nullptr, tempStorageBytes,
+                                      rawKeys, rawResult, numItems, numSegments,
+                                      rawOffsets, rawOffsets + 1);
+
+   CHAIDataGetter<char, RAJADeviceExec> charGetter {};
+   care::host_device_ptr<char> tempStorage(tempStorageBytes);
+   auto* rawTempStorage = charGetter.getRawArrayData(tempStorage);
+   cub::DeviceSegmentedSort::SortKeys(rawTempStorage, tempStorageBytes,
+                                      rawKeys, rawResult, numItems, numSegments,
+                                      rawOffsets, rawOffsets + 1);
+
+   tempStorage.free();
+
+   if (keys.isSlice()) {
+      care::host_device_ptr<const KeyT> source = result;
+
+      CARE_STREAM_LOOP(i, 0, numItems) {
+         keys[i] = source[i];
+      } CARE_STREAM_LOOP_END
+
+      result.free();
+   } else {
+      keys.free();
+      keys = std::move(result);
+   }
+}
+
+} // namespace care::cuda
+
+#endif // CARE_CUDA_SORT_H

--- a/src/care/hip/sort.h
+++ b/src/care/hip/sort.h
@@ -1,0 +1,72 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lawrence Livermore National Security, LLC and other CARE
+// contributors. See the CARE LICENSE and COPYRIGHT files for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef CARE_HIP_SORT_H
+#define CARE_HIP_SORT_H
+
+#include "care/CHAIDataGetter.h"
+#include "care/DefaultMacros.h"
+#include "care/host_device_ptr.h"
+
+#include <cstddef>
+#include <utility>
+
+#include "rocprim/rocprim.hpp"
+
+namespace care::hip {
+
+template <typename KeyT, typename OffsetT>
+CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,
+                                care::host_device_ptr<OffsetT> const& offsets)
+{
+   const size_t numSegments = offsets.size() > 0 ? offsets.size() - 1 : 0;
+   const size_t numItems = keys.size();
+
+   if (numSegments == 0 || numItems == 0) {
+      return;
+   }
+
+   CHAIDataGetter<KeyT, RAJADeviceExec> keyGetter {};
+   auto* rawKeys = keyGetter.getRawArrayData(keys);
+
+   CHAIDataGetter<OffsetT, RAJADeviceExec> offsetGetter {};
+   const auto* rawOffsets = offsetGetter.getConstRawArrayData(offsets);
+
+   care::host_device_ptr<KeyT> result(numItems);
+   auto* rawResult = keyGetter.getRawArrayData(result);
+
+   size_t tempStorageBytes = 0;
+   rocprim::segmented_radix_sort_keys(nullptr, tempStorageBytes,
+                                      rawKeys, rawResult, numItems, numSegments,
+                                      rawOffsets, rawOffsets + 1);
+
+   CHAIDataGetter<char, RAJADeviceExec> charGetter {};
+   care::host_device_ptr<char> tempStorage(tempStorageBytes);
+   auto* rawTempStorage = charGetter.getRawArrayData(tempStorage);
+   rocprim::segmented_radix_sort_keys(rawTempStorage, tempStorageBytes,
+                                      rawKeys, rawResult, numItems, numSegments,
+                                      rawOffsets, rawOffsets + 1);
+
+   tempStorage.free();
+
+   if (keys.isSlice()) {
+      care::host_device_ptr<const KeyT> source = result;
+
+      CARE_STREAM_LOOP(i, 0, numItems) {
+         keys[i] = source[i];
+      } CARE_STREAM_LOOP_END
+
+      result.free();
+   } else {
+      keys.free();
+      keys = std::move(result);
+   }
+}
+
+} // namespace care::hip
+
+#endif // CARE_HIP_SORT_H

--- a/src/care/host/sort.h
+++ b/src/care/host/sort.h
@@ -1,0 +1,36 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lawrence Livermore National Security, LLC and other CARE
+// contributors. See the CARE LICENSE and COPYRIGHT files for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef CARE_HOST_SORT_H
+#define CARE_HOST_SORT_H
+
+#include "care/host_device_ptr.h"
+
+#include <algorithm>
+#include <cstddef>
+
+namespace care::host {
+
+template <typename KeyT, typename OffsetT>
+void segmented_sort(care::host_device_ptr<KeyT>& keys,
+                    care::host_device_ptr<OffsetT> const& offsets)
+{
+   const size_t numSegments = offsets.size() > 0 ? offsets.size() - 1 : 0;
+
+   KeyT* rawKeys = keys.data();
+   const OffsetT* rawOffsets = offsets.cdata();
+
+   for (size_t segment = 0; segment < numSegments; ++segment) {
+      const size_t begin = static_cast<size_t>(rawOffsets[segment]);
+      const size_t end = static_cast<size_t>(rawOffsets[segment + 1]);
+      std::sort(rawKeys + begin, rawKeys + end);
+   }
+}
+
+} // namespace care::host
+
+#endif // CARE_HOST_SORT_H

--- a/src/care/sort.h
+++ b/src/care/sort.h
@@ -1,0 +1,38 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lawrence Livermore National Security, LLC and other CARE
+// contributors. See the CARE LICENSE and COPYRIGHT files for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef CARE_SORT_H
+#define CARE_SORT_H
+
+#include "care/host_device_ptr.h"
+
+#if defined(__CUDACC__)
+#include "care/cuda/sort.h"
+#elif defined(__HIPCC__)
+#include "care/hip/sort.h"
+#else
+#include "care/host/sort.h"
+#endif
+
+namespace care {
+
+template <typename KeyT, typename OffsetT>
+CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,
+                                care::host_device_ptr<OffsetT> const& offsets)
+{
+#if defined(__CUDACC__)
+   care::cuda::segmented_sort(keys, offsets);
+#elif defined(__HIPCC__)
+   care::hip::segmented_sort(keys, offsets);
+#else
+   care::host::segmented_sort(keys, offsets);
+#endif
+}
+
+} // namespace care
+
+#endif // CARE_SORT_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,19 @@ target_include_directories(TestAlgorithm
 blt_add_test( NAME TestAlgorithm
               COMMAND TestAlgorithm )
 
+blt_add_executable( NAME TestSegmentedSort
+                    SOURCES TestSegmentedSort.cpp
+                    DEPENDS_ON ${care_test_dependencies} )
+
+target_include_directories(TestSegmentedSort
+                           PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
+target_include_directories(TestSegmentedSort
+                           PRIVATE ${PROJECT_BINARY_DIR}/include)
+
+blt_add_test( NAME TestSegmentedSort
+              COMMAND TestSegmentedSort )
+
 blt_add_executable( NAME TestKeyValueSorter
                     SOURCES TestKeyValueSorter.cpp
                     DEPENDS_ON ${care_test_dependencies} )

--- a/test/TestSegmentedSort.cpp
+++ b/test/TestSegmentedSort.cpp
@@ -1,0 +1,62 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lawrence Livermore National Security, LLC and other CARE
+// contributors. See the CARE LICENSE and COPYRIGHT files for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
+#include "care/sort.h"
+#include "care/detail/test_utils.h"
+
+#include "gtest/gtest.h"
+
+TEST(segmented_sort, segment_local_and_empty)
+{
+#ifdef CARE_GPUCC
+   init_care_for_testing();
+#endif
+
+   care::host_device_ptr<int> keys(8);
+   care::host_device_ptr<int> offsets(5);
+
+   const int input[] = {5, 1, 4, 9, 3, 8, 7, 2};
+   const int segmentOffsets[] = {0, 3, 3, 6, 8};
+   const int expected[] = {1, 4, 5, 3, 8, 9, 2, 7};
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 8) {
+      keys[i] = input[i];
+   } CARE_SEQUENTIAL_LOOP_END
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 5) {
+      offsets[i] = segmentOffsets[i];
+   } CARE_SEQUENTIAL_LOOP_END
+
+   care::segmented_sort(keys, offsets);
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 8) {
+      EXPECT_EQ(keys[i], expected[i]);
+   } CARE_SEQUENTIAL_LOOP_END
+
+   offsets.free();
+   keys.free();
+}
+
+TEST(segmented_sort, empty_input)
+{
+#ifdef CARE_GPUCC
+   init_care_for_testing();
+#endif
+
+   care::host_device_ptr<int> keys;
+   care::host_device_ptr<int> offsets(1);
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 1) {
+      offsets[i] = 0;
+   } CARE_SEQUENTIAL_LOOP_END
+
+   care::segmented_sort(keys, offsets);
+   offsets.free();
+
+   EXPECT_EQ(keys.size(), 0);
+   EXPECT_EQ(keys.data(), nullptr);
+}


### PR DESCRIPTION
A segmented sort is used when many small arrays need to be sorted. They are all put into one contiguous array and offsets to each segment are provided. The algorithm sorts each segment independently. 