### PR TITLE
Fixes for segmented sort

### DIFF
--- a/src/care/cuda/sort.h
+++ b/src/care/cuda/sort.h
@@ -24,7 +24,8 @@ namespace care::cuda {
  * @param keys Keys to sort in place.
  * @param offsets Segment boundaries. For N segments, offsets must contain
  * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
- * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]). The
+ * entries must be monotonically nondecreasing and within [0, keys.size()].
  */
 template <typename KeyT, typename OffsetT>
 CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,

--- a/src/care/cuda/sort.h
+++ b/src/care/cuda/sort.h
@@ -24,8 +24,10 @@ namespace care::cuda {
  * @param keys Keys to sort in place.
  * @param offsets Segment boundaries. For N segments, offsets must contain
  * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
- * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]). The
- * entries must be monotonically nondecreasing and within [0, keys.size()].
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ * The entries must form a nondecreasing sequence from 0 to keys.size(); that
+ * is, offsets[0] must be 0 and offsets[N] must equal keys.size(). Repeated
+ * entries denote empty segments.
  */
 template <typename KeyT, typename OffsetT>
 CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,

--- a/src/care/cuda/sort.h
+++ b/src/care/cuda/sort.h
@@ -19,6 +19,13 @@
 
 namespace care::cuda {
 
+/**
+ * @brief Sort keys in ascending order independently within each segment.
+ * @param keys Keys to sort in place.
+ * @param offsets Segment boundaries. For N segments, offsets must contain
+ * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ */
 template <typename KeyT, typename OffsetT>
 CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,
                                 care::host_device_ptr<OffsetT> const& offsets)

--- a/src/care/hip/sort.h
+++ b/src/care/hip/sort.h
@@ -24,8 +24,10 @@ namespace care::hip {
  * @param keys Keys to sort in place.
  * @param offsets Segment boundaries. For N segments, offsets must contain
  * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
- * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]). The
- * entries must be monotonically nondecreasing and within [0, keys.size()].
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ * The entries must form a nondecreasing sequence from 0 to keys.size(); that
+ * is, offsets[0] must be 0 and offsets[N] must equal keys.size(). Repeated
+ * entries denote empty segments.
  */
 template <typename KeyT, typename OffsetT>
 CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,

--- a/src/care/hip/sort.h
+++ b/src/care/hip/sort.h
@@ -19,6 +19,13 @@
 
 namespace care::hip {
 
+/**
+ * @brief Sort keys in ascending order independently within each segment.
+ * @param keys Keys to sort in place.
+ * @param offsets Segment boundaries. For N segments, offsets must contain
+ * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ */
 template <typename KeyT, typename OffsetT>
 CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,
                                 care::host_device_ptr<OffsetT> const& offsets)

--- a/src/care/hip/sort.h
+++ b/src/care/hip/sort.h
@@ -24,7 +24,8 @@ namespace care::hip {
  * @param keys Keys to sort in place.
  * @param offsets Segment boundaries. For N segments, offsets must contain
  * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
- * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]). The
+ * entries must be monotonically nondecreasing and within [0, keys.size()].
  */
 template <typename KeyT, typename OffsetT>
 CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,

--- a/src/care/host/sort.h
+++ b/src/care/host/sort.h
@@ -15,6 +15,13 @@
 
 namespace care::host {
 
+/**
+ * @brief Sort keys in ascending order independently within each segment.
+ * @param keys Keys to sort in place.
+ * @param offsets Segment boundaries. For N segments, offsets must contain
+ * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ */
 template <typename KeyT, typename OffsetT>
 void segmented_sort(care::host_device_ptr<KeyT>& keys,
                     care::host_device_ptr<OffsetT> const& offsets)

--- a/src/care/host/sort.h
+++ b/src/care/host/sort.h
@@ -20,8 +20,10 @@ namespace care::host {
  * @param keys Keys to sort in place.
  * @param offsets Segment boundaries. For N segments, offsets must contain
  * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
- * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]). The
- * entries must be monotonically nondecreasing and within [0, keys.size()].
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ * The entries must form a nondecreasing sequence from 0 to keys.size(); that
+ * is, offsets[0] must be 0 and offsets[N] must equal keys.size(). Repeated
+ * entries denote empty segments.
  */
 template <typename KeyT, typename OffsetT>
 void segmented_sort(care::host_device_ptr<KeyT>& keys,

--- a/src/care/host/sort.h
+++ b/src/care/host/sort.h
@@ -20,7 +20,8 @@ namespace care::host {
  * @param keys Keys to sort in place.
  * @param offsets Segment boundaries. For N segments, offsets must contain
  * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
- * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]). The
+ * entries must be monotonically nondecreasing and within [0, keys.size()].
  */
 template <typename KeyT, typename OffsetT>
 void segmented_sort(care::host_device_ptr<KeyT>& keys,

--- a/src/care/sort.h
+++ b/src/care/sort.h
@@ -20,6 +20,13 @@
 
 namespace care {
 
+/**
+ * @brief Sort keys in ascending order independently within each segment.
+ * @param keys Keys to sort in place.
+ * @param offsets Segment boundaries. For N segments, offsets must contain
+ * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ */
 template <typename KeyT, typename OffsetT>
 CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,
                                 care::host_device_ptr<OffsetT> const& offsets)

--- a/src/care/sort.h
+++ b/src/care/sort.h
@@ -25,8 +25,10 @@ namespace care {
  * @param keys Keys to sort in place.
  * @param offsets Segment boundaries. For N segments, offsets must contain
  * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
- * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]). The
- * entries must be monotonically nondecreasing and within [0, keys.size()].
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ * The entries must form a nondecreasing sequence from 0 to keys.size(); that
+ * is, offsets[0] must be 0 and offsets[N] must equal keys.size(). Repeated
+ * entries denote empty segments.
  */
 template <typename KeyT, typename OffsetT>
 CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,

--- a/src/care/sort.h
+++ b/src/care/sort.h
@@ -25,7 +25,8 @@ namespace care {
  * @param keys Keys to sort in place.
  * @param offsets Segment boundaries. For N segments, offsets must contain
  * N + 1 entries: offsets[i] begins segment i, and offsets[N] marks the end of
- * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]).
+ * the final segment. Segment i is therefore [offsets[i], offsets[i + 1]). The
+ * entries must be monotonically nondecreasing and within [0, keys.size()].
  */
 template <typename KeyT, typename OffsetT>
 CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,

--- a/test/TestSegmentedSort.cpp
+++ b/test/TestSegmentedSort.cpp
@@ -12,16 +12,22 @@
 
 TEST(segmented_sort, segment_local_and_empty)
 {
-#ifdef CARE_GPUCC
-   init_care_for_testing();
-#endif
-
    care::host_device_ptr<int> keys(8);
    care::host_device_ptr<int> offsets(5);
 
-   const int input[] = {5, 1, 4, 9, 3, 8, 7, 2};
+   const int input[] = {
+      5, 1, 4,
+      // empty segment
+      9, 3, 8,
+      7, 2
+   };
    const int segmentOffsets[] = {0, 3, 3, 6, 8};
-   const int expected[] = {1, 4, 5, 3, 8, 9, 2, 7};
+   const int expected[] = {
+      1, 4, 5,
+      // empty segment
+      3, 8, 9,
+      2, 7
+   };
 
    CARE_SEQUENTIAL_LOOP(i, 0, 8) {
       keys[i] = input[i];
@@ -41,12 +47,36 @@ TEST(segmented_sort, segment_local_and_empty)
    keys.free();
 }
 
+TEST(segmented_sort, preserves_slice)
+{
+   care::host_device_ptr<int> storage(6);
+   care::host_device_ptr<int> keys = storage.slice(1, 4);
+   care::host_device_ptr<int> offsets(3);
+
+   const int input[] = {-1, 4, 2, 5, 3, -2};
+   const int segmentOffsets[] = {0, 2, 4};
+   const int expected[] = {-1, 2, 4, 3, 5, -2};
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 6) {
+      storage[i] = input[i];
+   } CARE_SEQUENTIAL_LOOP_END
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 3) {
+      offsets[i] = segmentOffsets[i];
+   } CARE_SEQUENTIAL_LOOP_END
+
+   care::segmented_sort(keys, offsets);
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 6) {
+      EXPECT_EQ(storage[i], expected[i]);
+   } CARE_SEQUENTIAL_LOOP_END
+
+   offsets.free();
+   storage.free();
+}
+
 TEST(segmented_sort, empty_input)
 {
-#ifdef CARE_GPUCC
-   init_care_for_testing();
-#endif
-
    care::host_device_ptr<int> keys;
    care::host_device_ptr<int> offsets(1);
 
@@ -59,4 +89,15 @@ TEST(segmented_sort, empty_input)
 
    EXPECT_EQ(keys.size(), 0);
    EXPECT_EQ(keys.data(), nullptr);
+}
+
+int main(int argc, char** argv)
+{
+   testing::InitGoogleTest(&argc, argv);
+
+#ifdef CARE_GPUCC
+   init_care_for_testing();
+#endif
+
+   return RUN_ALL_TESTS();
 }

--- a/test/TestSegmentedSort.cpp
+++ b/test/TestSegmentedSort.cpp
@@ -53,9 +53,19 @@ TEST(segmented_sort, preserves_slice)
    care::host_device_ptr<int> keys = storage.slice(1, 4);
    care::host_device_ptr<int> offsets(3);
 
-   const int input[] = {-1, 4, 2, 5, 3, -2};
+   const int input[] = {
+      -1, // before slice
+      4, 2,
+      5, 3,
+      -2 // after slice
+   };
    const int segmentOffsets[] = {0, 2, 4};
-   const int expected[] = {-1, 2, 4, 3, 5, -2};
+   const int expected[] = {
+      -1, // before slice
+      2, 4,
+      3, 5,
+      -2 // after slice
+   };
 
    CARE_SEQUENTIAL_LOOP(i, 0, 6) {
       storage[i] = input[i];

--- a/test/TestSegmentedSort.cpp
+++ b/test/TestSegmentedSort.cpp
@@ -47,6 +47,43 @@ TEST(segmented_sort, segment_local_and_empty)
    keys.free();
 }
 
+TEST(segmented_sort, preserves_gaps_before_and_after_segments)
+{
+   care::host_device_ptr<int> keys(9);
+   care::host_device_ptr<int> offsets(3);
+
+   const int input[] = {
+      -2, -1, // gap before first segment
+      5, 1, 4,
+      9, 3,
+      -4, -3 // gap after final segment
+   };
+   const int segmentOffsets[] = {2, 5, 7};
+   const int expected[] = {
+      -2, -1, // gap before first segment
+      1, 4, 5,
+      3, 9,
+      -4, -3 // gap after final segment
+   };
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 9) {
+      keys[i] = input[i];
+   } CARE_SEQUENTIAL_LOOP_END
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 3) {
+      offsets[i] = segmentOffsets[i];
+   } CARE_SEQUENTIAL_LOOP_END
+
+   care::segmented_sort(keys, offsets);
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 9) {
+      EXPECT_EQ(keys[i], expected[i]);
+   } CARE_SEQUENTIAL_LOOP_END
+
+   offsets.free();
+   keys.free();
+}
+
 TEST(segmented_sort, preserves_slice)
 {
    care::host_device_ptr<int> storage(6);

--- a/test/TestSegmentedSort.cpp
+++ b/test/TestSegmentedSort.cpp
@@ -47,43 +47,6 @@ TEST(segmented_sort, segment_local_and_empty)
    keys.free();
 }
 
-TEST(segmented_sort, preserves_gaps_before_and_after_segments)
-{
-   care::host_device_ptr<int> keys(9);
-   care::host_device_ptr<int> offsets(3);
-
-   const int input[] = {
-      -2, -1, // gap before first segment
-      5, 1, 4,
-      9, 3,
-      -4, -3 // gap after final segment
-   };
-   const int segmentOffsets[] = {2, 5, 7};
-   const int expected[] = {
-      -2, -1, // gap before first segment
-      1, 4, 5,
-      3, 9,
-      -4, -3 // gap after final segment
-   };
-
-   CARE_SEQUENTIAL_LOOP(i, 0, 9) {
-      keys[i] = input[i];
-   } CARE_SEQUENTIAL_LOOP_END
-
-   CARE_SEQUENTIAL_LOOP(i, 0, 3) {
-      offsets[i] = segmentOffsets[i];
-   } CARE_SEQUENTIAL_LOOP_END
-
-   care::segmented_sort(keys, offsets);
-
-   CARE_SEQUENTIAL_LOOP(i, 0, 9) {
-      EXPECT_EQ(keys[i], expected[i]);
-   } CARE_SEQUENTIAL_LOOP_END
-
-   offsets.free();
-   keys.free();
-}
-
 TEST(segmented_sort, preserves_slice)
 {
    care::host_device_ptr<int> storage(6);


### PR DESCRIPTION
* Fixes test cases (tried and failed to create the same umpire allocator multiple times)
* Made the segments more obvious in the test cases
* Added a test case to exercise slices
* Added documentation to segmented_sort functions