### PR TITLE
Add segmented_sort_and_unique

### DIFF
--- a/src/care/cuda/sort.h
+++ b/src/care/cuda/sort.h
@@ -11,6 +11,7 @@
 #include "care/CHAIDataGetter.h"
 #include "care/DefaultMacros.h"
 #include "care/host_device_ptr.h"
+#include "care/scan.h"
 
 #include <cstddef>
 #include <utility>
@@ -75,6 +76,100 @@ CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,
       keys.free();
       keys = std::move(result);
    }
+}
+
+/**
+ * @brief Sort each segment and copy its unique keys into a compact array.
+ *
+ * Equal keys in different segments remain distinct. Empty segments are
+ * preserved in @p uniqueOffsets.
+ */
+template <typename KeyT, typename OffsetT>
+CARE_INLINE void segmented_sort_and_unique(
+   care::host_device_ptr<KeyT> const& keys,
+   care::host_device_ptr<OffsetT> const& offsets,
+   care::host_device_ptr<KeyT>& uniqueKeys,
+   care::host_device_ptr<OffsetT>& uniqueOffsets)
+{
+   const size_t numItems = keys.size();
+   const size_t numSegments = offsets.size() > 0 ? offsets.size() - 1 : 0;
+
+   care::host_device_ptr<KeyT> sortedKeys(numItems);
+   CARE_STREAM_LOOP(i, 0, numItems) {
+      sortedKeys[i] = keys[i];
+   } CARE_STREAM_LOOP_END
+
+   segmented_sort(sortedKeys, offsets);
+
+   // The final scan entry holds the total number of unique keys.
+   care::host_device_ptr<size_t> positions(numItems + 1);
+   CARE_STREAM_LOOP(i, 0, numItems + 1) {
+      positions[i] = 0;
+   } CARE_STREAM_LOOP_END
+
+   CARE_STREAM_LOOP(i, 0, numItems) {
+      positions[i] = static_cast<size_t>(
+         i == 0 || sortedKeys[i - 1] < sortedKeys[i] ||
+         sortedKeys[i] < sortedKeys[i - 1]);
+   } CARE_STREAM_LOOP_END
+
+   // Segment starts are always unique, including when adjacent segments end
+   // and begin with equal keys.
+   CARE_STREAM_LOOP(segment, 0, numSegments) {
+      const OffsetT begin = offsets[segment];
+      if (begin < offsets[segment + 1]) {
+         positions[begin] = 1;
+      }
+   } CARE_STREAM_LOOP_END
+
+   care::exclusive_scan(RAJADeviceExec {}, positions, nullptr,
+                        static_cast<int>(numItems + 1), size_t {}, true);
+
+   const size_t numUnique = positions.pick(numItems);
+   care::host_device_ptr<KeyT> result(numUnique);
+   care::host_device_ptr<OffsetT> resultOffsets(offsets.size());
+
+   CARE_STREAM_LOOP(i, 0, numItems) {
+      if (positions[i] != positions[i + 1]) {
+         result[positions[i]] = sortedKeys[i];
+      }
+   } CARE_STREAM_LOOP_END
+
+   CARE_STREAM_LOOP(segment, 0, offsets.size()) {
+      resultOffsets[segment] =
+         static_cast<OffsetT>(positions[offsets[segment]]);
+   } CARE_STREAM_LOOP_END
+
+   positions.free();
+   sortedKeys.free();
+
+   uniqueKeys.free();
+   uniqueOffsets.free();
+   uniqueKeys = std::move(result);
+   uniqueOffsets = std::move(resultOffsets);
+}
+
+/**
+ * @brief Replace segmented keys and offsets with sorted unique results.
+ */
+template <typename KeyT, typename OffsetT>
+CARE_INLINE void segmented_sort_and_unique(
+   care::host_device_ptr<KeyT>& keys,
+   care::host_device_ptr<OffsetT>& offsets)
+{
+   care::host_device_ptr<KeyT> uniqueKeys;
+   care::host_device_ptr<OffsetT> uniqueOffsets;
+
+   segmented_sort_and_unique(
+      static_cast<care::host_device_ptr<KeyT> const&>(keys),
+      static_cast<care::host_device_ptr<OffsetT> const&>(offsets),
+      uniqueKeys,
+      uniqueOffsets);
+
+   keys.free();
+   offsets.free();
+   keys = std::move(uniqueKeys);
+   offsets = std::move(uniqueOffsets);
 }
 
 } // namespace care::cuda

--- a/src/care/hip/sort.h
+++ b/src/care/hip/sort.h
@@ -11,6 +11,7 @@
 #include "care/CHAIDataGetter.h"
 #include "care/DefaultMacros.h"
 #include "care/host_device_ptr.h"
+#include "care/scan.h"
 
 #include <cstddef>
 #include <utility>
@@ -75,6 +76,100 @@ CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,
       keys.free();
       keys = std::move(result);
    }
+}
+
+/**
+ * @brief Sort each segment and copy its unique keys into a compact array.
+ *
+ * Equal keys in different segments remain distinct. Empty segments are
+ * preserved in @p uniqueOffsets.
+ */
+template <typename KeyT, typename OffsetT>
+CARE_INLINE void segmented_sort_and_unique(
+   care::host_device_ptr<KeyT> const& keys,
+   care::host_device_ptr<OffsetT> const& offsets,
+   care::host_device_ptr<KeyT>& uniqueKeys,
+   care::host_device_ptr<OffsetT>& uniqueOffsets)
+{
+   const size_t numItems = keys.size();
+   const size_t numSegments = offsets.size() > 0 ? offsets.size() - 1 : 0;
+
+   care::host_device_ptr<KeyT> sortedKeys(numItems);
+   CARE_STREAM_LOOP(i, 0, numItems) {
+      sortedKeys[i] = keys[i];
+   } CARE_STREAM_LOOP_END
+
+   segmented_sort(sortedKeys, offsets);
+
+   // The final scan entry holds the total number of unique keys.
+   care::host_device_ptr<size_t> positions(numItems + 1);
+   CARE_STREAM_LOOP(i, 0, numItems + 1) {
+      positions[i] = 0;
+   } CARE_STREAM_LOOP_END
+
+   CARE_STREAM_LOOP(i, 0, numItems) {
+      positions[i] = static_cast<size_t>(
+         i == 0 || sortedKeys[i - 1] < sortedKeys[i] ||
+         sortedKeys[i] < sortedKeys[i - 1]);
+   } CARE_STREAM_LOOP_END
+
+   // Segment starts are always unique, including when adjacent segments end
+   // and begin with equal keys.
+   CARE_STREAM_LOOP(segment, 0, numSegments) {
+      const OffsetT begin = offsets[segment];
+      if (begin < offsets[segment + 1]) {
+         positions[begin] = 1;
+      }
+   } CARE_STREAM_LOOP_END
+
+   care::exclusive_scan(RAJADeviceExec {}, positions, nullptr,
+                        static_cast<int>(numItems + 1), size_t {}, true);
+
+   const size_t numUnique = positions.pick(numItems);
+   care::host_device_ptr<KeyT> result(numUnique);
+   care::host_device_ptr<OffsetT> resultOffsets(offsets.size());
+
+   CARE_STREAM_LOOP(i, 0, numItems) {
+      if (positions[i] != positions[i + 1]) {
+         result[positions[i]] = sortedKeys[i];
+      }
+   } CARE_STREAM_LOOP_END
+
+   CARE_STREAM_LOOP(segment, 0, offsets.size()) {
+      resultOffsets[segment] =
+         static_cast<OffsetT>(positions[offsets[segment]]);
+   } CARE_STREAM_LOOP_END
+
+   positions.free();
+   sortedKeys.free();
+
+   uniqueKeys.free();
+   uniqueOffsets.free();
+   uniqueKeys = std::move(result);
+   uniqueOffsets = std::move(resultOffsets);
+}
+
+/**
+ * @brief Replace segmented keys and offsets with sorted unique results.
+ */
+template <typename KeyT, typename OffsetT>
+CARE_INLINE void segmented_sort_and_unique(
+   care::host_device_ptr<KeyT>& keys,
+   care::host_device_ptr<OffsetT>& offsets)
+{
+   care::host_device_ptr<KeyT> uniqueKeys;
+   care::host_device_ptr<OffsetT> uniqueOffsets;
+
+   segmented_sort_and_unique(
+      static_cast<care::host_device_ptr<KeyT> const&>(keys),
+      static_cast<care::host_device_ptr<OffsetT> const&>(offsets),
+      uniqueKeys,
+      uniqueOffsets);
+
+   keys.free();
+   offsets.free();
+   keys = std::move(uniqueKeys);
+   offsets = std::move(uniqueOffsets);
 }
 
 } // namespace care::hip

--- a/src/care/host/sort.h
+++ b/src/care/host/sort.h
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <utility>
 
 namespace care::host {
 
@@ -39,6 +40,91 @@ void segmented_sort(care::host_device_ptr<KeyT>& keys,
       const size_t end = static_cast<size_t>(rawOffsets[segment + 1]);
       std::sort(rawKeys + begin, rawKeys + end);
    }
+}
+
+/**
+ * @brief Sort each segment and copy its unique keys into a compact array.
+ *
+ * Equal keys in different segments remain distinct. Empty segments are
+ * preserved in @p uniqueOffsets.
+ */
+template <typename KeyT, typename OffsetT>
+void segmented_sort_and_unique(
+   care::host_device_ptr<KeyT> const& keys,
+   care::host_device_ptr<OffsetT> const& offsets,
+   care::host_device_ptr<KeyT>& uniqueKeys,
+   care::host_device_ptr<OffsetT>& uniqueOffsets)
+{
+   const size_t numItems = keys.size();
+   const size_t numSegments = offsets.size() > 0 ? offsets.size() - 1 : 0;
+   const KeyT* rawKeys = keys.cdata();
+   const OffsetT* rawOffsets = offsets.cdata();
+
+   care::host_device_ptr<KeyT> result(numItems);
+   KeyT* rawResult = result.data();
+   if (numItems > 0) {
+      std::copy(rawKeys, rawKeys + numItems, rawResult);
+   }
+
+   care::host_device_ptr<OffsetT> resultOffsets(offsets.size());
+   OffsetT* rawResultOffsets = resultOffsets.data();
+
+   size_t output = 0;
+   for (size_t segment = 0; segment < numSegments; ++segment) {
+      rawResultOffsets[segment] = static_cast<OffsetT>(output);
+
+      const size_t begin = static_cast<size_t>(rawOffsets[segment]);
+      const size_t end = static_cast<size_t>(rawOffsets[segment + 1]);
+
+      if (begin < end) {
+         std::sort(rawResult + begin, rawResult + end);
+
+         KeyT previous = rawResult[begin];
+         rawResult[output++] = previous;
+
+         for (size_t i = begin + 1; i < end; ++i) {
+            KeyT current = rawResult[i];
+            if (previous < current || current < previous) {
+               rawResult[output++] = current;
+            }
+            previous = current;
+         }
+      }
+   }
+
+   if (offsets.size() > 0) {
+      rawResultOffsets[numSegments] = static_cast<OffsetT>(output);
+   }
+
+   result.realloc(output);
+
+   uniqueKeys.free();
+   uniqueOffsets.free();
+   uniqueKeys = std::move(result);
+   uniqueOffsets = std::move(resultOffsets);
+}
+
+/**
+ * @brief Replace segmented keys and offsets with sorted unique results.
+ */
+template <typename KeyT, typename OffsetT>
+void segmented_sort_and_unique(
+   care::host_device_ptr<KeyT>& keys,
+   care::host_device_ptr<OffsetT>& offsets)
+{
+   care::host_device_ptr<KeyT> uniqueKeys;
+   care::host_device_ptr<OffsetT> uniqueOffsets;
+
+   segmented_sort_and_unique(
+      static_cast<care::host_device_ptr<KeyT> const&>(keys),
+      static_cast<care::host_device_ptr<OffsetT> const&>(offsets),
+      uniqueKeys,
+      uniqueOffsets);
+
+   keys.free();
+   offsets.free();
+   keys = std::move(uniqueKeys);
+   offsets = std::move(uniqueOffsets);
 }
 
 } // namespace care::host

--- a/src/care/sort.h
+++ b/src/care/sort.h
@@ -43,6 +43,67 @@ CARE_INLINE void segmented_sort(care::host_device_ptr<KeyT>& keys,
 #endif
 }
 
+/**
+ * @brief Sort each segment and copy its unique keys into a compact array.
+ *
+ * Equal keys in different segments remain distinct. Empty segments are
+ * preserved in @p uniqueOffsets.
+ *
+ * @param keys Keys containing all input segments.
+ * @param offsets Input segment boundaries. For N segments, offsets must
+ * contain N + 1 entries: offsets[i] begins segment i, and offsets[N] marks
+ * the end of the final segment. The entries must form a nondecreasing
+ * sequence from 0 to keys.size(). Repeated entries denote empty segments.
+ * @param uniqueKeys Compact output containing the sorted unique keys from
+ * every segment. This array must not alias @p keys or @p offsets.
+ * @param uniqueOffsets Output segment boundaries into @p uniqueKeys. It has
+ * the same number of entries as @p offsets and must not alias an input.
+ */
+template <typename KeyT, typename OffsetT>
+CARE_INLINE void segmented_sort_and_unique(
+   care::host_device_ptr<KeyT> const& keys,
+   care::host_device_ptr<OffsetT> const& offsets,
+   care::host_device_ptr<KeyT>& uniqueKeys,
+   care::host_device_ptr<OffsetT>& uniqueOffsets)
+{
+#if defined(__CUDACC__)
+   care::cuda::segmented_sort_and_unique(
+      keys, offsets, uniqueKeys, uniqueOffsets);
+#elif defined(__HIPCC__)
+   care::hip::segmented_sort_and_unique(
+      keys, offsets, uniqueKeys, uniqueOffsets);
+#else
+   care::host::segmented_sort_and_unique(
+      keys, offsets, uniqueKeys, uniqueOffsets);
+#endif
+}
+
+/**
+ * @brief Replace segmented keys and offsets with sorted unique results.
+ *
+ * This overload replaces both allocations, so slices are detached from their
+ * original backing allocations. Use the four-argument overload when the input
+ * handles must remain unchanged.
+ *
+ * @param keys Keys containing all input segments. Replaced by the compact
+ * sorted unique keys.
+ * @param offsets Segment boundaries into @p keys. Replaced by boundaries into
+ * the compact result.
+ */
+template <typename KeyT, typename OffsetT>
+CARE_INLINE void segmented_sort_and_unique(
+   care::host_device_ptr<KeyT>& keys,
+   care::host_device_ptr<OffsetT>& offsets)
+{
+#if defined(__CUDACC__)
+   care::cuda::segmented_sort_and_unique(keys, offsets);
+#elif defined(__HIPCC__)
+   care::hip::segmented_sort_and_unique(keys, offsets);
+#else
+   care::host::segmented_sort_and_unique(keys, offsets);
+#endif
+}
+
 } // namespace care
 
 #endif // CARE_SORT_H

--- a/test/TestSegmentedSort.cpp
+++ b/test/TestSegmentedSort.cpp
@@ -106,6 +106,122 @@ TEST(segmented_sort, preserves_slice)
    storage.free();
 }
 
+// Verify that sorting and uniquing compacts each segment independently,
+// preserves empty segments, and leaves the input arrays unchanged.
+TEST(segmented_sort_and_unique, out_of_place)
+{
+   care::host_device_ptr<int> keys(10);
+   care::host_device_ptr<int> offsets(5);
+   care::host_device_ptr<int> uniqueKeys(1);
+   care::host_device_ptr<int> uniqueOffsets(1);
+
+   const int input[] = {
+      4, 1, 4,
+      // empty segment
+      8, 7, 8, 7,
+      5, 5, 4
+   };
+   const int segmentOffsets[] = {0, 3, 3, 7, 10};
+   const int expectedKeys[] = {1, 4, 7, 8, 4, 5};
+   const int expectedOffsets[] = {0, 2, 2, 4, 6};
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 10) {
+      keys[i] = input[i];
+   } CARE_SEQUENTIAL_LOOP_END
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 5) {
+      offsets[i] = segmentOffsets[i];
+   } CARE_SEQUENTIAL_LOOP_END
+
+   care::segmented_sort_and_unique(
+      keys, offsets, uniqueKeys, uniqueOffsets);
+
+   ASSERT_EQ(uniqueKeys.size(), 6);
+   ASSERT_EQ(uniqueOffsets.size(), 5);
+   CARE_SEQUENTIAL_LOOP(i, 0, 6) {
+      EXPECT_EQ(uniqueKeys[i], expectedKeys[i]);
+   } CARE_SEQUENTIAL_LOOP_END
+   CARE_SEQUENTIAL_LOOP(i, 0, 5) {
+      EXPECT_EQ(uniqueOffsets[i], expectedOffsets[i]);
+   } CARE_SEQUENTIAL_LOOP_END
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 10) {
+      EXPECT_EQ(keys[i], input[i]);
+   } CARE_SEQUENTIAL_LOOP_END
+   CARE_SEQUENTIAL_LOOP(i, 0, 5) {
+      EXPECT_EQ(offsets[i], segmentOffsets[i]);
+   } CARE_SEQUENTIAL_LOOP_END
+
+   uniqueOffsets.free();
+   uniqueKeys.free();
+   offsets.free();
+   keys.free();
+}
+
+// Verify that the replacement overload updates both arrays and their sizes.
+TEST(segmented_sort_and_unique, replaces_inputs)
+{
+   care::host_device_ptr<int> keys(9);
+   care::host_device_ptr<int> offsets(4);
+
+   const int input[] = {
+      3, 2, 3,
+      1, 1, 2, 1,
+      2, 2
+   };
+   const int segmentOffsets[] = {0, 3, 7, 9};
+   const int expectedKeys[] = {2, 3, 1, 2, 2};
+   const int expectedOffsets[] = {0, 2, 4, 5};
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 9) {
+      keys[i] = input[i];
+   } CARE_SEQUENTIAL_LOOP_END
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 4) {
+      offsets[i] = segmentOffsets[i];
+   } CARE_SEQUENTIAL_LOOP_END
+
+   care::segmented_sort_and_unique(keys, offsets);
+
+   ASSERT_EQ(keys.size(), 5);
+   ASSERT_EQ(offsets.size(), 4);
+   CARE_SEQUENTIAL_LOOP(i, 0, 5) {
+      EXPECT_EQ(keys[i], expectedKeys[i]);
+   } CARE_SEQUENTIAL_LOOP_END
+   CARE_SEQUENTIAL_LOOP(i, 0, 4) {
+      EXPECT_EQ(offsets[i], expectedOffsets[i]);
+   } CARE_SEQUENTIAL_LOOP_END
+
+   offsets.free();
+   keys.free();
+}
+
+// Verify that empty input and multiple empty segments produce empty output
+// while retaining every segment boundary.
+TEST(segmented_sort_and_unique, empty_input)
+{
+   care::host_device_ptr<int> keys;
+   care::host_device_ptr<int> offsets(4);
+   care::host_device_ptr<int> uniqueKeys;
+   care::host_device_ptr<int> uniqueOffsets;
+
+   CARE_SEQUENTIAL_LOOP(i, 0, 4) {
+      offsets[i] = 0;
+   } CARE_SEQUENTIAL_LOOP_END
+
+   care::segmented_sort_and_unique(
+      keys, offsets, uniqueKeys, uniqueOffsets);
+
+   EXPECT_EQ(uniqueKeys.size(), 0);
+   ASSERT_EQ(uniqueOffsets.size(), 4);
+   CARE_SEQUENTIAL_LOOP(i, 0, 4) {
+      EXPECT_EQ(uniqueOffsets[i], 0);
+   } CARE_SEQUENTIAL_LOOP_END
+
+   uniqueOffsets.free();
+   offsets.free();
+}
+
 int main(int argc, char** argv)
 {
    testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
A segmented sort and unique is used when each of many small arrays need to be sorted and uniqued. The small arrays are all combined into one contiguous array and offsets to each segment are provided. The algorithm does a sort and unique on each segment independently.