### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/care/KeyValueSorter_decl.h
+++ b/src/care/KeyValueSorter_decl.h
@@ -111,7 +111,7 @@ inline sortKeyValueArrays(host_device_ptr<KeyT> & keys,
                           const size_t start, const size_t len,
                           const bool noCopy=false)
 {
-   bool _noCopy ;
+   [[maybe_unused]] bool _noCopy ;
    if (noCopy && start > 0) {
       printf("[CARE] Warning: sortKeyValueArrays. noCopy should not be set if start > 0 (%d)\n", (int)start);
       _noCopy = false;
@@ -228,7 +228,7 @@ inline sortKeyValueArrays(host_device_ptr<KeyT> & keys,
                           const size_t start, const size_t len,
                           const bool noCopy=false)
 {
-   bool _noCopy ;
+   [[maybe_unused]] bool _noCopy ;
    if (noCopy && start > 0) {
       printf("[CARE] Warning: sortKeyValueArrays. noCopy should not be set if start > 0 (%d)\n", (int)start);
       _noCopy = false;

--- a/src/care/LoopFuser.h
+++ b/src/care/LoopFuser.h
@@ -28,8 +28,8 @@ namespace care {
   // TODO: Use if constexpr when supported
   template <typename T, typename T_PTR, std::enable_if_t<std::is_null_pointer<T_PTR>::value>* = nullptr>
    inline void wrappedFreeDeviceMemory(care::host_device_ptr<T> & array,
-                                       T_PTR freeDeviceCPUDestination,
-                                       size_t elems) {
+                                       [[maybe_unused]] T_PTR freeDeviceCPUDestination,
+                                       [[maybe_unused]] size_t elems) {
       array.freeDeviceMemory(nullptr, 0);
    }
 

--- a/src/care/ProfilePlugin.cpp
+++ b/src/care/ProfilePlugin.cpp
@@ -32,7 +32,7 @@ namespace care{
       static RAJA::util::PluginRegistry::add<care::ProfilePlugin> L ("Profile plugin", "CARE plugin for profiling");
    }
 
-   void ProfilePlugin::preLaunch(const RAJA::util::PluginContext& p) {
+   void ProfilePlugin::preLaunch([[maybe_unused]] const RAJA::util::PluginContext& p) {
 #if defined(__CUDACC__)
       // Profile the host loops
       if (s_profile_host_loops && p.platform == RAJA::Platform::host) {
@@ -54,7 +54,7 @@ namespace care{
    }
 
 
-   void ProfilePlugin::postLaunch(const RAJA::util::PluginContext& p) {
+   void ProfilePlugin::postLaunch([[maybe_unused]] const RAJA::util::PluginContext& p) {
 #if defined(__CUDACC__)
       if (s_profile_host_loops && p.platform == RAJA::Platform::host) {
          // TODO: Add error checking

--- a/src/care/algorithm_impl.h
+++ b/src/care/algorithm_impl.h
@@ -300,7 +300,7 @@ CARE_INLINE void IntersectArrays(RAJA::seq_exec exec,
  *             start1=0, then matches1 will contain 2. However, if start1 was 1, then matches will contain 2-start1=1.
  ************************************************************************/
 template <typename T>
-CARE_INLINE void IntersectArrays(RAJA::seq_exec exec,
+CARE_INLINE void IntersectArrays(RAJA::seq_exec,
                                  care::host_device_ptr<const T> arr1, int size1, int start1,
                                  care::host_device_ptr<const T> arr2, int size2, int start2,
                                  care::host_device_ptr<int> &matches1,

--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -418,8 +418,8 @@ namespace care {
       //     *CPU_destination will be updated with a deep copy of this data
       //
       // TODO: Should this really live in chai::ManagedArray?
-      void freeDeviceMemory(T_non_const ** CPU_destination,
-                            size_t elems,
+      void freeDeviceMemory([[maybe_unused]] T_non_const ** CPU_destination,
+                            [[maybe_unused]] size_t elems,
                             bool deregisterPointer=true) {
 #if defined(CARE_DEEP_COPY_RAW_PTR)
          // if there is a pointer to update ...

--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -205,9 +205,8 @@ namespace care {
       ///
       /// Convert to a host_device_ptr<const T>
       ///
-      // Keep the conversion target dependent on U.  When T is already const,
-      // spelling the target as host_device_ptr<const T> declares a conversion
-      // to the same type, which Clang correctly warns can never be used.
+      /// @note U keeps the conversion target dependent,
+      ///       avoiding self-conversion warnings.
       template<typename U = T>
          requires (!std::is_const_v<U>)
       CARE_HOST_DEVICE operator host_device_ptr<const U> () const {

--- a/src/care/host_device_ptr.h
+++ b/src/care/host_device_ptr.h
@@ -205,10 +205,13 @@ namespace care {
       ///
       /// Convert to a host_device_ptr<const T>
       ///
-      template<bool B = std::is_const<T>::value,
-               typename std::enable_if<!B, int>::type = 0>
-      CARE_HOST_DEVICE operator host_device_ptr<const T> () const {
-         return *reinterpret_cast<host_device_ptr<const T> const *> (this);
+      // Keep the conversion target dependent on U.  When T is already const,
+      // spelling the target as host_device_ptr<const T> declares a conversion
+      // to the same type, which Clang correctly warns can never be used.
+      template<typename U = T>
+         requires (!std::is_const_v<U>)
+      CARE_HOST_DEVICE operator host_device_ptr<const U> () const {
+         return *reinterpret_cast<host_device_ptr<const U> const *> (this);
       }
 
       ///
@@ -530,4 +533,3 @@ namespace care {
 
 
 #endif // !defined(_CARE_HOST_DEVICE_PTR_H_)
-

--- a/src/care/scan_impl.h
+++ b/src/care/scan_impl.h
@@ -60,12 +60,12 @@ void exclusive_scan(chai::ManagedArray<T> data, //!< [in/out] Input data (output
       if (size > 1) {
          bool warned = false;
 
-         if (data.size() < size) {
+         if (data.size() < static_cast<size_t>(size)) {
             printf("[CARE] Warning: Invalid arguments to care::exclusive_scan. Size of input array (%zu) is less than given size (%d).\n", data.size(), size);
             warned = true;
          }
 
-         if (!inPlace && outData.size() < size) {
+         if (!inPlace && outData.size() < static_cast<size_t>(size)) {
             printf("[CARE] Warning: Invalid arguments to care::exclusive_scan. Size of output array (%zu) is less than given size (%d).\n", outData.size(), size);
             warned = true;
          }
@@ -130,12 +130,12 @@ void inclusive_scan(chai::ManagedArray<T> data, chai::ManagedArray<T> outData,
 
       bool warned = false;
 
-      if (data.size() < size) {
+      if (data.size() < static_cast<size_t>(size)) {
          printf("[CARE] Warning: Invalid arguments to care::inclusive_scan. Size of input array (%zu) is less than given size (%d).\n", data.size(), size);
          warned = true;
       }
 
-      if (!inPlace && outData.size() < size) {
+      if (!inPlace && outData.size() < static_cast<size_t>(size)) {
          printf("[CARE] Warning: Invalid arguments to care::inclusive_scan. Size of output array (%zu) is less than given size (%d).\n", outData.size(), size);
          warned = true;
       }
@@ -350,4 +350,3 @@ void inclusive_scan(CARE_SCAN_EXEC, chai::ManagedArray<const GIDTYPE> inData, ch
 } // namespace care
 
 #undef CARE_SCAN_EXEC
-


### PR DESCRIPTION
* Fixed "src/care/host_device_ptr.h:210:24: warning: conversion function converting 'care::host_device_ptr<const double>' to itself will never be used [-Wclass-conversion]"

* Fixed unused variable warnings

* Fixed sign compare warnings